### PR TITLE
fix: point homepage language links to per-language pages

### DIFF
--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -31,13 +31,13 @@ import ThemeSwitcher from '../components/ThemeSwitcher.astro';
 
       <section class="frontpage-links">
         <nav class="frontpage-meta">
-          <a href="/implementations#python">Python</a>
-          <a href="/implementations#typescript">TypeScript</a>
-          <a href="/implementations#r">R</a>
-          <a href="/implementations#c">C#</a>
-          <a href="/implementations#kotlin">Kotlin</a>
-          <a href="/implementations#rust">Rust</a>
-          <a href="/implementations#go">Go</a>
+          <a href="/py">Python</a>
+          <a href="/ts">TypeScript</a>
+          <a href="/r">R</a>
+          <a href="/cs">C#</a>
+          <a href="/kt">Kotlin</a>
+          <a href="/rs">Rust</a>
+          <a href="/go">Go</a>
         </nav>
         <p class="frontpage-meta">
           <a href="https://github.com/AndreyAkinshin/pragmastat">github.com/AndreyAkinshin/pragmastat</a>


### PR DESCRIPTION
The homepage language buttons linked to `/implementations#<lang>`, but no `/implementations` route exists, so the links were dead. Each now points to its real per-language page (`/py`, `/ts`, `/r`, `/cs`, `/kt`, `/rs`, `/go`).

Closes #52
