### PR TITLE
chore: allow *.local dev hosts for network preview

### DIFF
--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -33,4 +33,10 @@ export default defineConfig({
       },
     },
   },
+  vite: {
+    server: {
+      // Local dev preview over mDNS: allow any *.local host.
+      allowedHosts: ['.local'],
+    },
+  },
 });


### PR DESCRIPTION
`astro dev --host` serves the site over the LAN, but Vite's host check rejects mDNS `*.local` hostnames, so previewing from another device fails with "Blocked request". Set `vite.server.allowedHosts: ['.local']` to accept any `*.local` host while non-`.local` hosts stay blocked.
