### PR TITLE
fix(ci): publish npm via tokenless trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -200,13 +200,13 @@ jobs:
     runs-on: ubuntu-24.04
     needs: build
     permissions:
-      id-token: write  # Required for npm provenance
+      id-token: write  # Mint the OIDC token for tokenless trusted publishing
       contents: read
     steps:
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '24'  # bundles npm >= 11.5.1, required for OIDC trusted publishing
         registry-url: 'https://registry.npmjs.org'
 
     - name: Download ts artifacts
@@ -216,10 +216,10 @@ jobs:
         path: ts/
 
     - name: Publish to npm
-      run: npm publish *.tgz --access public --provenance
+      # No NODE_AUTH_TOKEN: with no registry credential present, npm runs the OIDC
+      # exchange (tokenless trusted publishing) and generates provenance by default.
+      run: npm publish *.tgz --access public
       working-directory: ts
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-rs:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
The npm publish for v13.0.0 failed with a masked `E404` because the job never used trusted publishing: Node 20 ships npm 10.8.2, below the npm >= 11.5.1 floor for OIDC, and the step still set `NODE_AUTH_TOKEN` to the stale `NPM_TOKEN` secret, so npm took the classic token path and the dead token was rejected. Bump the runner to Node 24 (npm >= 11.5.1) and remove the `NODE_AUTH_TOKEN` env so npm performs the tokenless OIDC exchange; `--provenance` is automatic under trusted publishing and was dropped.

This only works if the npmjs.com trusted-publisher entry for `pragmastat` matches the run identity: owner `AndreyAkinshin`, repo `pragmastat`, workflow filename `publish.yml`, and a blank environment (the `publish-npm` job declares none). The `NPM_TOKEN` secret can be deleted once a publish succeeds.
