### PR TITLE
Modernize language toolchains

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,80 @@
+# Keep dependencies, base images, and Actions current automatically.
+# Grouped weekly PRs per ecosystem to avoid churn.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: ["*"]
+
+  - package-ecosystem: nuget
+    directory: /cs
+    schedule:
+      interval: weekly
+    groups:
+      nuget:
+        patterns: ["*"]
+
+  - package-ecosystem: gradle
+    directory: /kt
+    schedule:
+      interval: weekly
+    groups:
+      gradle:
+        patterns: ["*"]
+
+  - package-ecosystem: cargo
+    directories:
+      - /rs/pragmastat
+      - /rs/pragmastat-sim
+      - /tools
+    schedule:
+      interval: weekly
+    groups:
+      cargo:
+        patterns: ["*"]
+
+  - package-ecosystem: gomod
+    directory: /go
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directories:
+      - /ts
+      - /web
+    schedule:
+      interval: weekly
+    groups:
+      npm:
+        patterns: ["*"]
+
+  - package-ecosystem: pip
+    directories:
+      - /py
+      - /img
+    schedule:
+      interval: weekly
+    groups:
+      pip:
+        patterns: ["*"]
+
+  - package-ecosystem: docker
+    directories:
+      - /cs
+      - /go
+      - /img
+      - /kt
+      - /py
+      - /r
+      - /rs
+      - /ts
+      - /web
+    schedule:
+      interval: weekly
+    groups:
+      docker:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,10 @@ jobs:
   ci-manual:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up mise
-      uses: jdx/mise-action@v2
+      uses: jdx/mise-action@v4
 
     # --- Rust tools (for Typst → MDX conversion) ---
     - name: Set up Rust
@@ -47,9 +47,9 @@ jobs:
 
     # --- Image generation ---
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
-        python-version: '3.10'
+        python-version: '3.12'  # keep in sync with [tools].python in mise.toml
 
     - name: Install image dependencies
       run: |
@@ -62,7 +62,7 @@ jobs:
 
     # --- PDF generation ---
     - name: Install Typst
-      uses: typst-community/setup-typst@v4
+      uses: typst-community/setup-typst@v5
 
     - name: Download fonts
       run: mise run pdf:restore
@@ -83,7 +83,7 @@ jobs:
     # --- Upload artifacts (release only) ---
     - name: Upload web artifacts
       if: inputs.release
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: web
         path: web/dist
@@ -91,7 +91,7 @@ jobs:
 
     - name: Upload pdf artifacts
       if: inputs.release
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pdf
         path: manual/pragmastat.pdf
@@ -105,9 +105,9 @@ jobs:
   # Steps mirror mise tasks: r:check → r:build → r:test.
   ci-r:
     runs-on: ubuntu-24.04
-    container: rocker/verse:4.5.1
+    container: rocker/verse:4.6.1
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Install dependencies
       shell: bash
@@ -135,7 +135,7 @@ jobs:
 
     - name: Upload r artifacts
       if: inputs.release
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: r
         path: 'r/*.tar.gz'
@@ -144,15 +144,15 @@ jobs:
   ci-cs:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up mise
-      uses: jdx/mise-action@v2
+      uses: jdx/mise-action@v4
 
     - name: Set up .NET
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: '10.0.x'
+        dotnet-version: '10.0.x'  # keep in sync with [tools].dotnet in mise.toml
 
     - name: Check
       run: mise run cs:check
@@ -171,7 +171,7 @@ jobs:
 
     - name: Upload cs artifacts
       if: inputs.release
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: cs
         path: cs/artifacts
@@ -180,15 +180,15 @@ jobs:
   ci-py:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up mise
-      uses: jdx/mise-action@v2
+      uses: jdx/mise-action@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
-        python-version: '3.10'
+        python-version: '3.12'  # keep in sync with [tools].python in mise.toml
 
     - name: Install package and dependencies
       run: mise run py:restore
@@ -204,7 +204,7 @@ jobs:
 
     - name: Upload py artifacts
       if: inputs.release
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: py
         path: py/dist/
@@ -213,10 +213,10 @@ jobs:
   ci-rs:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up mise
-      uses: jdx/mise-action@v2
+      uses: jdx/mise-action@v4
 
     - name: Set up Rust
       uses: dtolnay/rust-toolchain@stable
@@ -242,7 +242,7 @@ jobs:
 
     - name: Upload rs artifacts
       if: inputs.release
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: rs
         path: rs/pragmastat/target/package/*.crate
@@ -251,15 +251,15 @@ jobs:
   ci-ts:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up mise
-      uses: jdx/mise-action@v2
+      uses: jdx/mise-action@v4
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: '20'
+        node-version: '22'  # keep in sync with [tools].node in mise.toml
         cache: 'pnpm'
         cache-dependency-path: ts/pnpm-lock.yaml
 
@@ -280,7 +280,7 @@ jobs:
 
     - name: Upload ts artifacts
       if: inputs.release
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ts
         path: ts/*.tgz
@@ -289,10 +289,10 @@ jobs:
   ci-go:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up mise
-      uses: jdx/mise-action@v2
+      uses: jdx/mise-action@v4
 
     - name: Download dependencies
       run: mise run go:restore
@@ -308,7 +308,7 @@ jobs:
 
     - name: Upload go artifacts
       if: inputs.release
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: go
         path: go/
@@ -317,19 +317,19 @@ jobs:
   ci-kt:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up mise
-      uses: jdx/mise-action@v2
+      uses: jdx/mise-action@v4
 
     - name: Set up JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
-        java-version: '11'
+        java-version: '21'  # sync: [tools].java in mise.toml (Gradle 9 daemon; jvmToolchain targets 11)
         distribution: 'temurin'
 
     - name: Cache Gradle packages
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       continue-on-error: true
       with:
         path: |
@@ -361,7 +361,7 @@ jobs:
 
     - name: Upload kt artifacts
       if: inputs.release
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: kt
         path: |
@@ -375,7 +375,7 @@ jobs:
 
   ci-success:
     name: CI Success
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [ci-manual, ci-r, ci-cs, ci-py, ci-rs, ci-ts, ci-go, ci-kt]
     if: always()
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: build
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Read version
       id: version
@@ -34,55 +34,55 @@ jobs:
         git push origin "v${{ steps.version.outputs.VERSION }}" "go/v${{ steps.version.outputs.VERSION }}"
 
     - name: Download web artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: web
         path: artifacts/web
 
     - name: Download pdf artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: pdf
         path: artifacts/pdf
 
     - name: Download cs artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: cs
         path: artifacts/cs
 
     - name: Download py artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: py
         path: artifacts/py
 
     - name: Download rs artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: rs
         path: artifacts/rs
 
     - name: Download ts artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: ts
         path: artifacts/ts
 
     - name: Download go artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: go
         path: artifacts/go
 
     - name: Download r artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: r
         path: artifacts/r
 
     - name: Download kt artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: kt
         path: artifacts/kt
@@ -109,7 +109,7 @@ jobs:
         cp artifacts/pdf/pragmastat.pdf "pragmastat-v${VERSION}.pdf"
 
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@v2.4.1
+      uses: softprops/action-gh-release@v3
       with:
         tag_name: v${{ steps.version.outputs.VERSION }}
         name: v${{ steps.version.outputs.VERSION }}
@@ -132,14 +132,14 @@ jobs:
     runs-on: ubuntu-24.04
     needs: build
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Read version
       id: version
       run: echo "VERSION=$(cat VERSION)" >> $GITHUB_OUTPUT
 
     - name: Download web artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: web
         path: web/public
@@ -162,15 +162,15 @@ jobs:
     runs-on: ubuntu-24.04
     needs: build
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up .NET
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: '10.0.x'
+        dotnet-version: '10.0.x'  # keep in sync with [tools].dotnet in mise.toml
 
     - name: Download cs artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: cs
         path: cs/artifacts
@@ -185,7 +185,7 @@ jobs:
       id-token: write  # Required for trusted publishing to PyPI
     steps:
     - name: Download py artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: py
         path: dist/
@@ -204,13 +204,13 @@ jobs:
       contents: read
     steps:
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: '24'  # bundles npm >= 11.5.1, required for OIDC trusted publishing
+        node-version: '24'  # npm OIDC needs npm >= 11.5.1 (Node 24); intentionally ahead of mise's node 22
         registry-url: 'https://registry.npmjs.org'
 
     - name: Download ts artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: ts
         path: ts/
@@ -225,13 +225,13 @@ jobs:
     runs-on: ubuntu-24.04
     needs: build
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up Rust
       uses: dtolnay/rust-toolchain@stable
 
     - name: Download rs artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: rs
         path: rs/pragmastat/target/package
@@ -244,16 +244,16 @@ jobs:
     runs-on: ubuntu-24.04
     needs: build
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
-        java-version: '11'
+        java-version: '21'  # sync: [tools].java in mise.toml (Gradle 9 daemon; jvmToolchain targets 11)
         distribution: 'temurin'
 
     - name: Cache Gradle packages
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       continue-on-error: true
       with:
         path: |
@@ -264,7 +264,7 @@ jobs:
           ${{ runner.os }}-gradle-
 
     - name: Download kt artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: kt
         path: kt/build/
@@ -284,7 +284,7 @@ jobs:
 
     - name: Upload build reports on failure
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: kt-build-reports
         path: kt/build/reports/

--- a/cs/Pragmastat/Exceptions/WeightedSampleNotSupportedException.cs
+++ b/cs/Pragmastat/Exceptions/WeightedSampleNotSupportedException.cs
@@ -1,4 +1,3 @@
-using System.Runtime.Serialization;
 using JetBrains.Annotations;
 
 namespace Pragmastat.Exceptions;
@@ -7,11 +6,6 @@ public class WeightedSampleNotSupportedException : ArgumentException
 {
   [PublicAPI]
   public WeightedSampleNotSupportedException()
-  {
-  }
-
-  [PublicAPI]
-  protected WeightedSampleNotSupportedException(SerializationInfo info, StreamingContext context) : base(info, context)
   {
   }
 

--- a/cs/Pragmastat/Pragmastat.csproj
+++ b/cs/Pragmastat/Pragmastat.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net6.0;net10.0</TargetFrameworks>
         <Description>Pragmatic Statistical Toolkit</Description>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageProjectUrl>https://pragmastat.dev</PackageProjectUrl>

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for Pragmastat Go implementation
-FROM golang:1.21-alpine
+FROM golang:1.26-alpine
 
 # Install git (required for some Go operations)
 RUN apk add --no-cache git bash

--- a/go/additive.go
+++ b/go/additive.go
@@ -41,7 +41,7 @@ func (a *Additive) Sample(rng *Rng) float64 {
 // Samples generates multiple samples from the additive distribution.
 func (a *Additive) Samples(rng *Rng, count int) []float64 {
 	result := make([]float64, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		result[i] = a.Sample(rng)
 	}
 	return result

--- a/go/center_impl.go
+++ b/go/center_impl.go
@@ -14,7 +14,7 @@ func deriveSeed[T Number](values []T) int64 {
 	hash := fnvOffsetBasis
 	for _, v := range values {
 		bits := math.Float64bits(float64(v))
-		for i := 0; i < 8; i++ {
+		for i := range 8 {
 			hash ^= (bits >> (i * 8)) & 0xff
 			hash *= fnvPrime
 		}
@@ -62,7 +62,7 @@ func centerImpl[T Number](values []T, assumeSorted bool) (float64, error) {
 	// Initialize search bounds for each row (1-based indexing)
 	leftBounds := make([]int64, n)
 	rightBounds := make([]int64, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		leftBounds[i] = int64(i + 1) // Row i pairs with columns [i+1..n]
 		rightBounds[i] = int64(n)
 	}
@@ -115,7 +115,7 @@ func centerImpl[T Number](values []T, assumeSorted bool) (float64, error) {
 			minActiveSum := math.Inf(1)
 			maxActiveSum := math.Inf(-1)
 
-			for i := 0; i < n; i++ {
+			for i := range n {
 				if leftBounds[i] > rightBounds[i] {
 					continue
 				}
@@ -146,7 +146,7 @@ func centerImpl[T Number](values []T, assumeSorted bool) (float64, error) {
 			largestBelowPivot := math.Inf(-1)
 			smallestAtOrAbovePivot := math.Inf(1)
 
-			for i := 0; i < n; i++ {
+			for i := range n {
 				countInRow := partitionCounts[i]
 				rowValue := sortedValues[i]
 				totalInRow := int64(n - i)
@@ -183,12 +183,12 @@ func centerImpl[T Number](values []T, assumeSorted bool) (float64, error) {
 		// === UPDATE BOUNDS ===
 		if countBelowPivot < medianRankLow {
 			// Too few values below pivot - search higher
-			for i := 0; i < n; i++ {
+			for i := range n {
 				leftBounds[i] = int64(i) + partitionCounts[i] + 1
 			}
 		} else {
 			// Too many values below pivot - search lower
-			for i := 0; i < n; i++ {
+			for i := range n {
 				rightBounds[i] = int64(i) + partitionCounts[i]
 			}
 		}
@@ -198,7 +198,7 @@ func centerImpl[T Number](values []T, assumeSorted bool) (float64, error) {
 
 		// Recalculate active set size
 		activeSetSize = 0
-		for i := 0; i < n; i++ {
+		for i := range n {
 			rowSize := rightBounds[i] - leftBounds[i] + 1
 			if rowSize > 0 {
 				activeSetSize += rowSize
@@ -226,7 +226,7 @@ func centerImpl[T Number](values []T, assumeSorted bool) (float64, error) {
 			cumulativeSize := int64(0)
 			selectedRow := 0
 
-			for i := 0; i < n; i++ {
+			for i := range n {
 				rowSize := rightBounds[i] - leftBounds[i] + 1
 				if rowSize > 0 {
 					if targetIndex < cumulativeSize+rowSize {
@@ -245,7 +245,7 @@ func centerImpl[T Number](values []T, assumeSorted bool) (float64, error) {
 			minRemainingSum := math.Inf(1)
 			maxRemainingSum := math.Inf(-1)
 
-			for i := 0; i < n; i++ {
+			for i := range n {
 				if leftBounds[i] > rightBounds[i] {
 					continue
 				}

--- a/go/center_quantiles_impl.go
+++ b/go/center_quantiles_impl.go
@@ -44,7 +44,7 @@ func centerCountPairsLessOrEqualImpl(sorted []float64, target float64) int64 {
 	// j is not reset: as i increases, threshold decreases monotonically
 	j := n - 1
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		threshold := 2*target - sorted[i]
 
 		for j >= 0 && sorted[j] > threshold {
@@ -98,7 +98,7 @@ func centerFindExactQuantileImpl(sorted []float64, k int64) float64 {
 	target := 0.5*lo + 0.5*hi
 	var candidates []float64
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		threshold := 2*target - sorted[i]
 
 		left := i

--- a/go/dualpath_test.go
+++ b/go/dualpath_test.go
@@ -132,7 +132,6 @@ func runScalarDualPath(t *testing.T, td TestData, entries []scalarEntry) {
 	t.Helper()
 	if len(td.ExpectedError) > 0 {
 		for _, e := range entries {
-			e := e
 			t.Run(e.name, func(t *testing.T) {
 				value, err, sampleCreation := e.run(t)
 				_ = value
@@ -156,7 +155,6 @@ func runScalarDualPath(t *testing.T, td TestData, entries []scalarEntry) {
 		t.Fatalf("Failed to parse output data: %v", err)
 	}
 	for _, e := range entries {
-		e := e
 		t.Run(e.name, func(t *testing.T) {
 			value, err, _ := e.run(t)
 			if err != nil {
@@ -175,7 +173,6 @@ func runBoundsDualPath(t *testing.T, td TestData, entries []boundsEntry) {
 	t.Helper()
 	if len(td.ExpectedError) > 0 {
 		for _, e := range entries {
-			e := e
 			t.Run(e.name, func(t *testing.T) {
 				_, err, sampleCreation := e.run(t)
 				checkSubject := true
@@ -195,7 +192,6 @@ func runBoundsDualPath(t *testing.T, td TestData, entries []boundsEntry) {
 		t.Fatalf("Failed to parse output data: %v", err)
 	}
 	for _, e := range entries {
-		e := e
 		t.Run(e.name, func(t *testing.T) {
 			b, err, _ := e.run(t)
 			if err != nil {

--- a/go/estimators.go
+++ b/go/estimators.go
@@ -525,7 +525,7 @@ func spreadBoundsInner(x []float64, misrate float64, rng *Rng) (Bounds, error) {
 	shuffled := RngShuffle(rng, indices)
 
 	diffs := make([]float64, m)
-	for i := 0; i < m; i++ {
+	for i := range m {
 		diffs[i] = math.Abs(x[shuffled[2*i]] - x[shuffled[2*i+1]])
 	}
 	sort.Float64s(diffs)

--- a/go/exp.go
+++ b/go/exp.go
@@ -31,7 +31,7 @@ func (e *Exp) Sample(rng *Rng) float64 {
 // Samples generates multiple samples from the exponential distribution.
 func (e *Exp) Samples(rng *Rng, count int) []float64 {
 	result := make([]float64, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		result[i] = e.Sample(rng)
 	}
 	return result

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,3 +1,3 @@
 module github.com/AndreyAkinshin/pragmastat/go/v13
 
-go 1.20
+go 1.25

--- a/go/multiplic.go
+++ b/go/multiplic.go
@@ -31,7 +31,7 @@ func (m *Multiplic) Sample(rng *Rng) float64 {
 // Samples generates multiple samples from the multiplicative distribution.
 func (m *Multiplic) Samples(rng *Rng, count int) []float64 {
 	result := make([]float64, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		result[i] = m.Sample(rng)
 	}
 	return result

--- a/go/pairwise_margin.go
+++ b/go/pairwise_margin.go
@@ -96,7 +96,7 @@ func pairwiseMarginExactRaw(n, m int, p float64) int {
 
 		// Compute pmf[u] using Loeffler recurrence
 		sum := 0.0
-		for i := 0; i < u; i++ {
+		for i := range u {
 			sum += pmf[i] * sigma[u-i]
 		}
 		sum /= float64(u)
@@ -217,7 +217,7 @@ func binomialCoefficient(n, k int) int64 {
 	}
 
 	result := int64(1)
-	for i := 0; i < k; i++ {
+	for i := range k {
 		result = result * int64(n-i) / int64(i+1)
 	}
 	return result

--- a/go/performance_test.go
+++ b/go/performance_test.go
@@ -10,7 +10,7 @@ import (
 func TestCenterPerformance(t *testing.T) {
 	n := 100000
 	x := make([]float64, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		x[i] = float64(i + 1)
 	}
 
@@ -39,7 +39,7 @@ func TestCenterPerformance(t *testing.T) {
 func TestSpreadPerformance(t *testing.T) {
 	n := 100000
 	x := make([]float64, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		x[i] = float64(i + 1)
 	}
 
@@ -69,7 +69,7 @@ func TestShiftPerformance(t *testing.T) {
 	n := 100000
 	x := make([]float64, n)
 	y := make([]float64, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		x[i] = float64(i + 1)
 		y[i] = float64(i + 1)
 	}

--- a/go/power.go
+++ b/go/power.go
@@ -35,7 +35,7 @@ func (p *Power) Sample(rng *Rng) float64 {
 // Samples generates multiple samples from the power distribution.
 func (p *Power) Samples(rng *Rng, count int) []float64 {
 	result := make([]float64, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		result[i] = p.Sample(rng)
 	}
 	return result

--- a/go/properties_test.go
+++ b/go/properties_test.go
@@ -136,7 +136,6 @@ func TestRawBoundsRejectMisrateDomain(t *testing.T) {
 	}
 
 	for _, m := range badMisrates {
-		m := m
 		t.Run("CenterBounds", func(t *testing.T) {
 			_, err := CenterBounds(x, m, false)
 			assertDomainMisrate(t, err, "CenterBounds")

--- a/go/reference_test.go
+++ b/go/reference_test.go
@@ -92,7 +92,6 @@ func TestReferenceData(t *testing.T) {
 		{"spread", Spread, (*Sample).Spread},
 	}
 	for _, est := range oneSampleScalar {
-		est := est
 		t.Run(est.name, func(t *testing.T) {
 			forEachFixture(t, est.name, func(t *testing.T, td TestData, input OneSampleInput) {
 				entries := []scalarEntry{
@@ -131,7 +130,6 @@ func TestReferenceData(t *testing.T) {
 		{"disparity", Disparity, func(x, y *Sample) (Measurement, error) { return x.Disparity(y) }},
 	}
 	for _, est := range twoSampleScalar {
-		est := est
 		t.Run(est.name, func(t *testing.T) {
 			forEachFixture(t, est.name, func(t *testing.T, td TestData, input TwoSampleInput) {
 				entries := []scalarEntry{
@@ -204,7 +202,6 @@ func TestReferenceData(t *testing.T) {
 		{"ratio-bounds", RatioBounds, func(x, y *Sample, m float64) (Bounds, error) { return x.RatioBounds(y, m) }},
 	}
 	for _, est := range twoSampleBounds {
-		est := est
 		t.Run(est.name, func(t *testing.T) {
 			forEachFixture(t, est.name, func(t *testing.T, td TestData, input ShiftBoundsInput) {
 				entries := []boundsEntry{
@@ -393,7 +390,7 @@ func TestRngUniformReference(t *testing.T) {
 			if len(testData.Output) != testData.Input.Count {
 				t.Fatalf("Output length %d != count %d", len(testData.Output), testData.Input.Count)
 			}
-			for i := 0; i < testData.Input.Count; i++ {
+			for i := range testData.Input.Count {
 				actual := rng.UniformFloat64()
 				expected := testData.Output[i]
 				if !floatEquals(actual, expected, 1e-15) {
@@ -436,7 +433,7 @@ func TestRngUniformIntReference(t *testing.T) {
 			if len(testData.Output) != testData.Input.Count {
 				t.Fatalf("Output length %d != count %d", len(testData.Output), testData.Input.Count)
 			}
-			for i := 0; i < testData.Input.Count; i++ {
+			for i := range testData.Input.Count {
 				actual := rng.UniformInt64(testData.Input.Min, testData.Input.Max)
 				expected := testData.Output[i]
 				if actual != expected {
@@ -480,7 +477,7 @@ func TestRngStringSeedReference(t *testing.T) {
 			if len(testData.Output) != testData.Input.Count {
 				t.Fatalf("Output length %d != count %d", len(testData.Output), testData.Input.Count)
 			}
-			for i := 0; i < testData.Input.Count; i++ {
+			for i := range testData.Input.Count {
 				actual := rng.UniformFloat64()
 				expected := testData.Output[i]
 				if !floatEquals(actual, expected, 1e-15) {
@@ -523,7 +520,7 @@ func TestRngUniformRangeReference(t *testing.T) {
 			if len(testData.Output) != testData.Input.Count {
 				t.Fatalf("Output length %d != count %d", len(testData.Output), testData.Input.Count)
 			}
-			for i := 0; i < testData.Input.Count; i++ {
+			for i := range testData.Input.Count {
 				actual := rng.UniformFloat64Range(testData.Input.Min, testData.Input.Max)
 				expected := testData.Output[i]
 				if !floatEquals(actual, expected, 1e-12) {
@@ -567,7 +564,7 @@ func TestRngUniformFloat32Reference(t *testing.T) {
 			if len(testData.Output) != testData.Input.Count {
 				t.Fatalf("Output length %d != count %d", len(testData.Output), testData.Input.Count)
 			}
-			for i := 0; i < testData.Input.Count; i++ {
+			for i := range testData.Input.Count {
 				actual := rng.UniformFloat32()
 				expected := testData.Output[i]
 				if actual != expected {
@@ -610,7 +607,7 @@ func TestRngUniformInt32Reference(t *testing.T) {
 			if len(testData.Output) != testData.Input.Count {
 				t.Fatalf("Output length %d != count %d", len(testData.Output), testData.Input.Count)
 			}
-			for i := 0; i < testData.Input.Count; i++ {
+			for i := range testData.Input.Count {
 				actual := rng.UniformInt32(testData.Input.Min, testData.Input.Max)
 				expected := testData.Output[i]
 				if actual != expected {
@@ -654,7 +651,7 @@ func TestRngUniformBoolReference(t *testing.T) {
 			if len(testData.Output) != testData.Input.Count {
 				t.Fatalf("Output length %d != count %d", len(testData.Output), testData.Input.Count)
 			}
-			for i := 0; i < testData.Input.Count; i++ {
+			for i := range testData.Input.Count {
 				actual := rng.UniformBool()
 				expected := testData.Output[i]
 				if actual != expected {
@@ -822,7 +819,7 @@ func TestUniformDistributionReference(t *testing.T) {
 			rng := NewRngFromSeed(testData.Input.Seed)
 			dist := NewUniform(testData.Input.Min, testData.Input.Max)
 
-			for i := 0; i < testData.Input.Count; i++ {
+			for i := range testData.Input.Count {
 				actual := dist.Sample(rng)
 				expected := testData.Output[i]
 				if !floatEquals(actual, expected, 1e-12) {
@@ -861,7 +858,7 @@ func TestAdditiveDistributionReference(t *testing.T) {
 			rng := NewRngFromSeed(testData.Input.Seed)
 			dist := NewAdditive(testData.Input.Mean, testData.Input.StdDev)
 
-			for i := 0; i < testData.Input.Count; i++ {
+			for i := range testData.Input.Count {
 				actual := dist.Sample(rng)
 				expected := testData.Output[i]
 				if !floatEquals(actual, expected, 1e-12) {
@@ -900,7 +897,7 @@ func TestMultiplicDistributionReference(t *testing.T) {
 			rng := NewRngFromSeed(testData.Input.Seed)
 			dist := NewMultiplic(testData.Input.LogMean, testData.Input.LogStdDev)
 
-			for i := 0; i < testData.Input.Count; i++ {
+			for i := range testData.Input.Count {
 				actual := dist.Sample(rng)
 				expected := testData.Output[i]
 				if !floatEquals(actual, expected, 1e-12) {
@@ -939,7 +936,7 @@ func TestExpDistributionReference(t *testing.T) {
 			rng := NewRngFromSeed(testData.Input.Seed)
 			dist := NewExp(testData.Input.Rate)
 
-			for i := 0; i < testData.Input.Count; i++ {
+			for i := range testData.Input.Count {
 				actual := dist.Sample(rng)
 				expected := testData.Output[i]
 				if !floatEquals(actual, expected, 1e-12) {
@@ -978,7 +975,7 @@ func TestPowerDistributionReference(t *testing.T) {
 			rng := NewRngFromSeed(testData.Input.Seed)
 			dist := NewPower(testData.Input.Min, testData.Input.Shape)
 
-			for i := 0; i < testData.Input.Count; i++ {
+			for i := range testData.Input.Count {
 				actual := dist.Sample(rng)
 				expected := testData.Output[i]
 				if !floatEquals(actual, expected, 1e-12) {

--- a/go/rng.go
+++ b/go/rng.go
@@ -201,7 +201,7 @@ func RngResample[T any](rng *Rng, x []T, k int) []T {
 
 	result := make([]T, k)
 	n := len(x)
-	for i := 0; i < k; i++ {
+	for i := range k {
 		result[i] = x[int(rng.UniformInt64(0, int64(n)))]
 	}
 	return result

--- a/go/sample_race_test.go
+++ b/go/sample_race_test.go
@@ -18,7 +18,7 @@ func TestSampleConcurrentEstimators(t *testing.T) {
 	var wg sync.WaitGroup
 	start := make(chan struct{})
 	wg.Add(goroutines)
-	for i := 0; i < goroutines; i++ {
+	for range goroutines {
 		go func() {
 			defer wg.Done()
 			<-start // release all goroutines simultaneously to widen the race window

--- a/go/shift_impl.go
+++ b/go/shift_impl.go
@@ -192,7 +192,7 @@ func countAndNeighbors[T Number](x, y []T, threshold float64) (int64, float64, f
 	minAbove := math.Inf(1)
 
 	j := 0
-	for i := 0; i < m; i++ {
+	for i := range m {
 		// Move j forward while x[i] - y[j] > threshold
 		for j < n && float64(x[i])-float64(y[j]) > threshold {
 			j++

--- a/go/spread_impl.go
+++ b/go/spread_impl.go
@@ -43,7 +43,7 @@ func spreadImpl[T Number](values []T, assumeSorted bool) (float64, error) {
 	// Row i allows j in [i+1, n-1] initially
 	L := make([]int, n)
 	R := make([]int, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		L[i] = i + 1
 		if L[i] >= n {
 			L[i] = n
@@ -85,7 +85,7 @@ func spreadImpl[T Number](values []T, assumeSorted bool) (float64, error) {
 		smallestAtOrAbove := math.Inf(1)
 
 		j := 1 // global two-pointer
-		for i := 0; i < n-1; i++ {
+		for i := range n - 1 {
 			if j < i+1 {
 				j = i + 1
 			}
@@ -134,7 +134,7 @@ func spreadImpl[T Number](values []T, assumeSorted bool) (float64, error) {
 			maxActive := math.Inf(-1)
 			active := int64(0)
 
-			for i := 0; i < n-1; i++ {
+			for i := range n - 1 {
 				Li, Ri := L[i], R[i]
 				if Li > Ri {
 					continue
@@ -174,7 +174,7 @@ func spreadImpl[T Number](values []T, assumeSorted bool) (float64, error) {
 		// === SHRINK ACTIVE WINDOW ===
 		if countBelow < kLow {
 			// Need larger differences: discard all strictly below pivot
-			for i := 0; i < n-1; i++ {
+			for i := range n - 1 {
 				newL := i + 1 + int(rowCounts[i])
 				if newL > L[i] {
 					L[i] = newL
@@ -186,7 +186,7 @@ func spreadImpl[T Number](values []T, assumeSorted bool) (float64, error) {
 			}
 		} else {
 			// Too many below: keep only those strictly below pivot
-			for i := 0; i < n-1; i++ {
+			for i := range n - 1 {
 				newR := i + int(rowCounts[i])
 				if newR < R[i] {
 					R[i] = newR
@@ -202,7 +202,7 @@ func spreadImpl[T Number](values []T, assumeSorted bool) (float64, error) {
 
 		// === CHOOSE NEXT PIVOT FROM ACTIVE SET ===
 		activeSize := int64(0)
-		for i := 0; i < n-1; i++ {
+		for i := range n - 1 {
 			if L[i] <= R[i] {
 				activeSize += int64(R[i] - L[i] + 1)
 			}
@@ -226,7 +226,7 @@ func spreadImpl[T Number](values []T, assumeSorted bool) (float64, error) {
 			// Few candidates left: return midrange of remaining
 			minRem := math.Inf(1)
 			maxRem := math.Inf(-1)
-			for i := 0; i < n-1; i++ {
+			for i := range n - 1 {
 				if L[i] > R[i] {
 					continue
 				}
@@ -258,6 +258,7 @@ func spreadImpl[T Number](values []T, assumeSorted bool) (float64, error) {
 		t := rng.UniformInt64(0, activeSize)
 		acc := int64(0)
 		var row int
+		//nolint:intrange // row is read after the loop (its break value), a range var would be out of scope
 		for row = 0; row < n-1; row++ {
 			if L[row] > R[row] {
 				continue

--- a/go/uniform.go
+++ b/go/uniform.go
@@ -23,7 +23,7 @@ func (u *Uniform) Sample(rng *Rng) float64 {
 // Samples generates multiple samples from the uniform distribution.
 func (u *Uniform) Samples(rng *Rng, count int) []float64 {
 	result := make([]float64, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		result[i] = u.Sample(rng)
 	}
 	return result

--- a/go/xoshiro256.go
+++ b/go/xoshiro256.go
@@ -187,7 +187,7 @@ const (
 // fnv1aHash computes FNV-1a 64-bit hash of a string
 func fnv1aHash(s string) uint64 {
 	hash := uint64(fnvOffsetBasis)
-	for i := 0; i < len(s); i++ {
+	for i := range len(s) {
 		hash ^= uint64(s[i])
 		hash *= fnvPrime
 	}

--- a/img/Dockerfile
+++ b/img/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for Pragmastat image generation
-FROM python:3.10-slim
+FROM python:3.12-slim
 
 # Set working directory to img
 WORKDIR /workspace/img

--- a/kt/Dockerfile
+++ b/kt/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for Pragmastat Kotlin implementation
-FROM eclipse-temurin:11-jdk
+FROM eclipse-temurin:21-jdk
 
 # Install bash
 RUN apt-get update && \

--- a/kt/build.gradle.kts
+++ b/kt/build.gradle.kts
@@ -1,10 +1,10 @@
 plugins {
-    kotlin("jvm") version "2.0.21"
+    kotlin("jvm") version "2.4.0"
     `maven-publish`
     signing
-    id("org.jetbrains.dokka") version "2.0.0"
-    id("org.jreleaser") version "1.20.0"
-    id("org.jlleitschuh.gradle.ktlint") version "12.1.2"
+    id("org.jetbrains.dokka") version "2.2.0"
+    id("org.jreleaser") version "1.25.0"
+    id("org.jlleitschuh.gradle.ktlint") version "14.2.0"
 }
 
 group = "dev.pragmastat"

--- a/kt/gradle/wrapper/gradle-wrapper.properties
+++ b/kt/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/kt/settings.gradle.kts
+++ b/kt/settings.gradle.kts
@@ -1,2 +1,8 @@
+plugins {
+    // Auto-provision the JDK 11 toolchain (jvmToolchain(11)) when the Gradle
+    // daemon runs on a newer JDK.
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
 rootProject.name = "pragmastat"
 include("demo")

--- a/kt/src/main/kotlin/dev/pragmastat/Assumptions.kt
+++ b/kt/src/main/kotlin/dev/pragmastat/Assumptions.kt
@@ -1,13 +1,17 @@
 package dev.pragmastat
 
-enum class AssumptionId(val id: String) {
+enum class AssumptionId(
+    val id: String,
+) {
     VALIDITY("validity"),
     DOMAIN("domain"),
     POSITIVITY("positivity"),
     SPARITY("sparity"),
 }
 
-enum class Subject(val id: String) {
+enum class Subject(
+    val id: String,
+) {
     X("x"),
     Y("y"),
     MISRATE("misrate"),
@@ -63,11 +67,10 @@ internal fun checkPositivity(
 internal fun log(
     values: List<Double>,
     subject: Subject,
-): List<Double> {
-    return values.map { v ->
+): List<Double> =
+    values.map { v ->
         if (v <= 0.0) {
             throw AssumptionException(Violation(AssumptionId.POSITIVITY, subject))
         }
         kotlin.math.ln(v)
     }
-}

--- a/kt/src/main/kotlin/dev/pragmastat/Compare.kt
+++ b/kt/src/main/kotlin/dev/pragmastat/Compare.kt
@@ -128,9 +128,7 @@ internal object CompareEngine {
         threshold: Threshold,
         x: Sample,
         unused: Sample?,
-    ): Measurement {
-        return validateCenter(threshold, x, null)
-    }
+    ): Measurement = validateCenter(threshold, x, null)
 
     private fun validateShift(
         threshold: Threshold,
@@ -244,8 +242,7 @@ internal object CompareEngine {
             thresholds
                 .mapIndexed { index, threshold ->
                     Triple(threshold, index, normalizedValues[index])
-                }
-                .groupBy { it.first.metric }
+                }.groupBy { it.first.metric }
 
         for (spec in specs) {
             val entries = byMetric[spec.metric] ?: continue

--- a/kt/src/main/kotlin/dev/pragmastat/Measurement.kt
+++ b/kt/src/main/kotlin/dev/pragmastat/Measurement.kt
@@ -15,13 +15,12 @@ data class Measurement(
     /** Returns the numeric value (alias for [value]). */
     fun toDouble(): Double = value
 
-    override fun toString(): String {
-        return if (unit.abbreviation.isNotEmpty()) {
+    override fun toString(): String =
+        if (unit.abbreviation.isNotEmpty()) {
             "${formatValue(value)} ${unit.abbreviation}"
         } else {
             formatValue(value)
         }
-    }
 }
 
 private fun formatValue(v: Double): String {

--- a/kt/src/main/kotlin/dev/pragmastat/PairwiseMargin.kt
+++ b/kt/src/main/kotlin/dev/pragmastat/PairwiseMargin.kt
@@ -51,9 +51,7 @@ private fun pairwiseMarginExact(
     n: Int,
     m: Int,
     misrate: Double,
-): Int {
-    return pairwiseMarginExactRaw(n, m, misrate / 2.0) * 2
-}
+): Int = pairwiseMarginExactRaw(n, m, misrate / 2.0) * 2
 
 /**
  * Uses Edgeworth approximation for large samples
@@ -62,9 +60,7 @@ private fun pairwiseMarginApprox(
     n: Int,
     m: Int,
     misrate: Double,
-): Int {
-    return pairwiseMarginApproxRaw(n, m, misrate / 2.0) * 2
-}
+): Int = pairwiseMarginApproxRaw(n, m, misrate / 2.0) * 2
 
 /**
  * Inversed implementation of Andreas Löffler's (1982)

--- a/kt/src/main/kotlin/dev/pragmastat/Probability.kt
+++ b/kt/src/main/kotlin/dev/pragmastat/Probability.kt
@@ -14,7 +14,9 @@ package dev.pragmastat
  * @property value The underlying probability value, guaranteed to be in [0, 1].
  */
 @JvmInline
-value class Probability(val value: Double) {
+value class Probability(
+    val value: Double,
+) {
     init {
         require(value in 0.0..1.0) { "Probability must be in [0, 1], got $value" }
     }

--- a/kt/src/main/kotlin/dev/pragmastat/Rng.kt
+++ b/kt/src/main/kotlin/dev/pragmastat/Rng.kt
@@ -25,7 +25,9 @@ package dev.pragmastat
  * val sampled = rng3.sample(listOf(0, 1, 2, 3, 4, 5, 6, 7, 8, 9), 3)
  * ```
  */
-class Rng private constructor(private val inner: Xoshiro256PlusPlus) {
+class Rng private constructor(
+    private val inner: Xoshiro256PlusPlus,
+) {
     /**
      * Create a new Rng with system entropy (non-deterministic).
      */

--- a/kt/src/main/kotlin/dev/pragmastat/Sample.kt
+++ b/kt/src/main/kotlin/dev/pragmastat/Sample.kt
@@ -82,14 +82,10 @@ class Sample private constructor(
     }
 
     /** Returns a new sample with each value multiplied by [scalar]. */
-    operator fun times(scalar: Double): Sample {
-        return Sample(values.map { it * scalar }, weights?.toList(), unit)
-    }
+    operator fun times(scalar: Double): Sample = Sample(values.map { it * scalar }, weights?.toList(), unit)
 
     /** Returns a new sample with [scalar] added to each value. */
-    operator fun plus(scalar: Double): Sample {
-        return Sample(values.map { it + scalar }, weights?.toList(), unit)
-    }
+    operator fun plus(scalar: Double): Sample = Sample(values.map { it + scalar }, weights?.toList(), unit)
 
     override fun toString(): String = "Sample(size=$size, unit=${unit.id})"
 
@@ -212,7 +208,8 @@ class Sample private constructor(
             misrate: Double,
         ): Bounds {
             checkNonWeighted("x", x)
-            return dev.pragmastat.centerBounds(x.sortedValues, misrate, assumeSorted = true)
+            return dev.pragmastat
+                .centerBounds(x.sortedValues, misrate, assumeSorted = true)
                 .withUnit(x.unit)
         }
 
@@ -239,7 +236,8 @@ class Sample private constructor(
             checkNonWeighted("x", x)
             checkNonWeighted("y", y)
             val (cx, cy) = preparePair(x, y)
-            return dev.pragmastat.shiftBounds(cx.sortedValues, cy.sortedValues, misrate, assumeSorted = true)
+            return dev.pragmastat
+                .shiftBounds(cx.sortedValues, cy.sortedValues, misrate, assumeSorted = true)
                 .withUnit(cx.unit)
         }
 
@@ -253,7 +251,8 @@ class Sample private constructor(
             val (cx, cy) = preparePair(x, y)
             // ratioBounds is order-independent and ln is monotonic, so log(sortedValues)
             // stays sorted — reuse the cached sorted view to skip a re-sort (matches ratio/shiftBounds).
-            return dev.pragmastat.ratioBounds(cx.sortedValues, cy.sortedValues, misrate, assumeSorted = true)
+            return dev.pragmastat
+                .ratioBounds(cx.sortedValues, cy.sortedValues, misrate, assumeSorted = true)
                 .withUnit(RatioUnit)
         }
 

--- a/kt/src/main/kotlin/dev/pragmastat/SignMargin.kt
+++ b/kt/src/main/kotlin/dev/pragmastat/SignMargin.kt
@@ -32,7 +32,11 @@ internal fun signMarginRandomized(
     return r * 2
 }
 
-private data class SplitResult(val rLow: Int, val logCdfLow: Double, val logPmfHigh: Double)
+private data class SplitResult(
+    val rLow: Int,
+    val logCdfLow: Double,
+    val logPmfHigh: Double,
+)
 
 private fun binomCdfSplit(
     n: Int,

--- a/kt/src/main/kotlin/dev/pragmastat/UnitRegistry.kt
+++ b/kt/src/main/kotlin/dev/pragmastat/UnitRegistry.kt
@@ -28,10 +28,9 @@ class UnitRegistry private constructor(
      *
      * @throws IllegalArgumentException if no unit with the given ID is registered
      */
-    fun resolve(id: String): MeasurementUnit {
-        return byId[id]
+    fun resolve(id: String): MeasurementUnit =
+        byId[id]
             ?: throw IllegalArgumentException("unknown unit id: '$id'")
-    }
 
     companion object {
         /** Returns a registry pre-populated with Number, Ratio, and Disparity units. */

--- a/kt/src/main/kotlin/dev/pragmastat/Xoshiro256.kt
+++ b/kt/src/main/kotlin/dev/pragmastat/Xoshiro256.kt
@@ -3,7 +3,9 @@ package dev.pragmastat
 /**
  * SplitMix64 PRNG for seed expansion.
  */
-internal class SplitMix64(private var state: ULong) {
+internal class SplitMix64(
+    private var state: ULong,
+) {
     fun next(): ULong {
         state += 0x9e3779b97f4a7c15UL
         var z = state
@@ -20,7 +22,9 @@ internal class SplitMix64(private var state: ULong) {
  * This is the jump-free version of the algorithm. It passes BigCrush
  * and is used by .NET 6+, Julia, and Rust's rand crate.
  */
-internal class Xoshiro256PlusPlus(seed: ULong) {
+internal class Xoshiro256PlusPlus(
+    seed: ULong,
+) {
     private var s0: ULong
     private var s1: ULong
     private var s2: ULong
@@ -175,9 +179,7 @@ internal class Xoshiro256PlusPlus(seed: ULong) {
     // Boolean Methods
     // ========================================================================
 
-    fun uniformBool(): Boolean {
-        return uniformDouble() < 0.5
-    }
+    fun uniformBool(): Boolean = uniformDouble() < 0.5
 }
 
 /**
@@ -219,6 +221,4 @@ internal object Fnv1a {
  * Derive a deterministic seed from input values using FNV-1a hash.
  * Ensures same input always produces same random sequence.
  */
-internal fun deriveSeed(values: List<Double>): Long {
-    return Fnv1a.hashDoubles(values).toLong()
-}
+internal fun deriveSeed(values: List<Double>): Long = Fnv1a.hashDoubles(values).toLong()

--- a/kt/src/main/kotlin/dev/pragmastat/distributions/Additive.kt
+++ b/kt/src/main/kotlin/dev/pragmastat/distributions/Additive.kt
@@ -14,7 +14,10 @@ import kotlin.math.*
  * @property stdDev Scale parameter (standard deviation).
  * @throws IllegalArgumentException If stdDev <= 0.
  */
-class Additive(private val mean: Double, private val stdDev: Double) : Distribution {
+class Additive(
+    private val mean: Double,
+    private val stdDev: Double,
+) : Distribution {
     init {
         require(stdDev > 0) { "stdDev must be positive" }
     }

--- a/kt/src/main/kotlin/dev/pragmastat/distributions/Distribution.kt
+++ b/kt/src/main/kotlin/dev/pragmastat/distributions/Distribution.kt
@@ -17,7 +17,5 @@ interface Distribution {
     fun samples(
         rng: Rng,
         count: Int,
-    ): List<Double> {
-        return (0 until count).map { sample(rng) }
-    }
+    ): List<Double> = (0 until count).map { sample(rng) }
 }

--- a/kt/src/main/kotlin/dev/pragmastat/distributions/Exp.kt
+++ b/kt/src/main/kotlin/dev/pragmastat/distributions/Exp.kt
@@ -13,7 +13,9 @@ import kotlin.math.ln
  * @property rate Rate parameter (lambda > 0).
  * @throws IllegalArgumentException If rate <= 0.
  */
-class Exp(private val rate: Double) : Distribution {
+class Exp(
+    private val rate: Double,
+) : Distribution {
     init {
         require(rate > 0) { "rate must be positive" }
     }

--- a/kt/src/main/kotlin/dev/pragmastat/distributions/Multiplic.kt
+++ b/kt/src/main/kotlin/dev/pragmastat/distributions/Multiplic.kt
@@ -13,7 +13,10 @@ import kotlin.math.exp
  * @property logStdDev Standard deviation of log values (scale parameter).
  * @throws IllegalArgumentException If logStdDev <= 0.
  */
-class Multiplic(private val logMean: Double, private val logStdDev: Double) : Distribution {
+class Multiplic(
+    private val logMean: Double,
+    private val logStdDev: Double,
+) : Distribution {
     private val additive: Additive
 
     init {
@@ -21,7 +24,5 @@ class Multiplic(private val logMean: Double, private val logStdDev: Double) : Di
         additive = Additive(logMean, logStdDev)
     }
 
-    override fun sample(rng: Rng): Double {
-        return exp(additive.sample(rng))
-    }
+    override fun sample(rng: Rng): Double = exp(additive.sample(rng))
 }

--- a/kt/src/main/kotlin/dev/pragmastat/distributions/Power.kt
+++ b/kt/src/main/kotlin/dev/pragmastat/distributions/Power.kt
@@ -14,7 +14,10 @@ import kotlin.math.pow
  * @property shape Shape parameter (alpha > 0, controls tail heaviness).
  * @throws IllegalArgumentException If min <= 0 or shape <= 0.
  */
-class Power(private val min: Double, private val shape: Double) : Distribution {
+class Power(
+    private val min: Double,
+    private val shape: Double,
+) : Distribution {
     init {
         require(min > 0) { "min must be positive" }
         require(shape > 0) { "shape must be positive" }

--- a/kt/src/main/kotlin/dev/pragmastat/distributions/Uniform.kt
+++ b/kt/src/main/kotlin/dev/pragmastat/distributions/Uniform.kt
@@ -11,12 +11,13 @@ import dev.pragmastat.Rng
  * @property max Upper bound (exclusive).
  * @throws IllegalArgumentException If min >= max.
  */
-class Uniform(private val min: Double, private val max: Double) : Distribution {
+class Uniform(
+    private val min: Double,
+    private val max: Double,
+) : Distribution {
     init {
         require(min < max) { "min must be less than max" }
     }
 
-    override fun sample(rng: Rng): Double {
-        return min + rng.uniformDouble() * (max - min)
-    }
+    override fun sample(rng: Rng): Double = min + rng.uniformDouble() * (max - min)
 }

--- a/kt/src/test/kotlin/dev/pragmastat/ReferenceTest.kt
+++ b/kt/src/test/kotlin/dev/pragmastat/ReferenceTest.kt
@@ -102,7 +102,9 @@ data class ProjectionOutput(
     val verdict: String,
 )
 
-data class Compare1Output(val projections: List<ProjectionOutput>)
+data class Compare1Output(
+    val projections: List<ProjectionOutput>,
+)
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Compare1TestData(
@@ -118,7 +120,9 @@ data class Compare2Input(
     val thresholds: List<CompareThresholdInput>,
 )
 
-data class Compare2Output(val projections: List<ProjectionOutput>)
+data class Compare2Output(
+    val projections: List<ProjectionOutput>,
+)
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Compare2TestData(
@@ -490,33 +494,77 @@ class ReferenceTest {
 
     // Rng reference tests
 
-    data class UniformInput(val seed: Long, val count: Int)
+    data class UniformInput(
+        val seed: Long,
+        val count: Int,
+    )
 
-    data class UniformTestData(val input: UniformInput, val output: List<Double>)
+    data class UniformTestData(
+        val input: UniformInput,
+        val output: List<Double>,
+    )
 
-    data class UniformIntInput(val seed: Long, val min: Long, val max: Long, val count: Int)
+    data class UniformIntInput(
+        val seed: Long,
+        val min: Long,
+        val max: Long,
+        val count: Int,
+    )
 
-    data class UniformIntTestData(val input: UniformIntInput, val output: List<Long>)
+    data class UniformIntTestData(
+        val input: UniformIntInput,
+        val output: List<Long>,
+    )
 
-    data class StringSeedInput(val seed: String, val count: Int)
+    data class StringSeedInput(
+        val seed: String,
+        val count: Int,
+    )
 
-    data class StringSeedTestData(val input: StringSeedInput, val output: List<Double>)
+    data class StringSeedTestData(
+        val input: StringSeedInput,
+        val output: List<Double>,
+    )
 
-    data class ShuffleInput(val seed: Long, val x: List<Double>)
+    data class ShuffleInput(
+        val seed: Long,
+        val x: List<Double>,
+    )
 
-    data class ShuffleTestData(val input: ShuffleInput, val output: List<Double>)
+    data class ShuffleTestData(
+        val input: ShuffleInput,
+        val output: List<Double>,
+    )
 
-    data class SampleInput(val seed: Long, val x: List<Double>, val k: Int)
+    data class SampleInput(
+        val seed: Long,
+        val x: List<Double>,
+        val k: Int,
+    )
 
-    data class SampleTestData(val input: SampleInput, val output: List<Double>)
+    data class SampleTestData(
+        val input: SampleInput,
+        val output: List<Double>,
+    )
 
-    data class ResampleTestData(val input: SampleInput, val output: List<Double>)
+    data class ResampleTestData(
+        val input: SampleInput,
+        val output: List<Double>,
+    )
 
     // Distribution reference tests
 
-    data class UniformDistInput(val seed: Long, val min: Double, val max: Double, val count: Int)
+    data class UniformDistInput(
+        val seed: Long,
+        val min: Double,
+        val max: Double,
+        val count: Int,
+    )
 
-    data class UniformDistTestData(val input: UniformDistInput, val output: List<Double>)
+    data class UniformDistTestData(
+        val input: UniformDistInput,
+        val output: List<Double>,
+    )
 
     data class AdditiveDistInput(
         val seed: Long,
@@ -525,7 +573,10 @@ class ReferenceTest {
         val count: Int,
     )
 
-    data class AdditiveDistTestData(val input: AdditiveDistInput, val output: List<Double>)
+    data class AdditiveDistTestData(
+        val input: AdditiveDistInput,
+        val output: List<Double>,
+    )
 
     data class MultiplicDistInput(
         val seed: Long,
@@ -534,32 +585,78 @@ class ReferenceTest {
         val count: Int,
     )
 
-    data class MultiplicDistTestData(val input: MultiplicDistInput, val output: List<Double>)
+    data class MultiplicDistTestData(
+        val input: MultiplicDistInput,
+        val output: List<Double>,
+    )
 
-    data class ExpDistInput(val seed: Long, val rate: Double, val count: Int)
+    data class ExpDistInput(
+        val seed: Long,
+        val rate: Double,
+        val count: Int,
+    )
 
-    data class ExpDistTestData(val input: ExpDistInput, val output: List<Double>)
+    data class ExpDistTestData(
+        val input: ExpDistInput,
+        val output: List<Double>,
+    )
 
-    data class PowerDistInput(val seed: Long, val min: Double, val shape: Double, val count: Int)
+    data class PowerDistInput(
+        val seed: Long,
+        val min: Double,
+        val shape: Double,
+        val count: Int,
+    )
 
-    data class PowerDistTestData(val input: PowerDistInput, val output: List<Double>)
+    data class PowerDistTestData(
+        val input: PowerDistInput,
+        val output: List<Double>,
+    )
 
     // New Rng test data classes
-    data class UniformRangeInput(val seed: Long, val min: Double, val max: Double, val count: Int)
+    data class UniformRangeInput(
+        val seed: Long,
+        val min: Double,
+        val max: Double,
+        val count: Int,
+    )
 
-    data class UniformRangeTestData(val input: UniformRangeInput, val output: List<Double>)
+    data class UniformRangeTestData(
+        val input: UniformRangeInput,
+        val output: List<Double>,
+    )
 
-    data class UniformF32Input(val seed: Long, val count: Int)
+    data class UniformF32Input(
+        val seed: Long,
+        val count: Int,
+    )
 
-    data class UniformF32TestData(val input: UniformF32Input, val output: List<Float>)
+    data class UniformF32TestData(
+        val input: UniformF32Input,
+        val output: List<Float>,
+    )
 
-    data class UniformI32Input(val seed: Long, val min: Int, val max: Int, val count: Int)
+    data class UniformI32Input(
+        val seed: Long,
+        val min: Int,
+        val max: Int,
+        val count: Int,
+    )
 
-    data class UniformI32TestData(val input: UniformI32Input, val output: List<Int>)
+    data class UniformI32TestData(
+        val input: UniformI32Input,
+        val output: List<Int>,
+    )
 
-    data class UniformBoolInput(val seed: Long, val count: Int)
+    data class UniformBoolInput(
+        val seed: Long,
+        val count: Int,
+    )
 
-    data class UniformBoolTestData(val input: UniformBoolInput, val output: List<Boolean>)
+    data class UniformBoolTestData(
+        val input: UniformBoolInput,
+        val output: List<Boolean>,
+    )
 
     @TestFactory
     fun testRngUniform(): List<DynamicTest> {
@@ -993,7 +1090,10 @@ class ReferenceTest {
 
     // One-sample bounds reference tests
 
-    data class SignedRankMarginInput(val n: Int, val misrate: Double)
+    data class SignedRankMarginInput(
+        val n: Int,
+        val misrate: Double,
+    )
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     data class SignedRankMarginTestData(
@@ -1002,7 +1102,10 @@ class ReferenceTest {
         @JsonProperty("expected_error") val expectedError: Map<String, String>? = null,
     )
 
-    data class CenterBoundsInput(val x: List<Double>, val misrate: Double)
+    data class CenterBoundsInput(
+        val x: List<Double>,
+        val misrate: Double,
+    )
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     data class CenterBoundsTestData(
@@ -1011,7 +1114,11 @@ class ReferenceTest {
         @JsonProperty("expected_error") val expectedError: Map<String, String>? = null,
     )
 
-    data class SpreadBoundsInput(val x: List<Double>, val misrate: Double, val seed: String)
+    data class SpreadBoundsInput(
+        val x: List<Double>,
+        val misrate: Double,
+        val seed: String,
+    )
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     data class SpreadBoundsTestData(
@@ -1020,7 +1127,12 @@ class ReferenceTest {
         @JsonProperty("expected_error") val expectedError: Map<String, String>? = null,
     )
 
-    data class AvgSpreadBoundsInput(val x: List<Double>, val y: List<Double>, val misrate: Double, val seed: String)
+    data class AvgSpreadBoundsInput(
+        val x: List<Double>,
+        val y: List<Double>,
+        val misrate: Double,
+        val seed: String,
+    )
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     data class AvgSpreadBoundsTestData(
@@ -1029,7 +1141,12 @@ class ReferenceTest {
         @JsonProperty("expected_error") val expectedError: Map<String, String>? = null,
     )
 
-    data class DisparityBoundsInput(val x: List<Double>, val y: List<Double>, val misrate: Double, val seed: String)
+    data class DisparityBoundsInput(
+        val x: List<Double>,
+        val y: List<Double>,
+        val misrate: Double,
+        val seed: String,
+    )
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     data class DisparityBoundsTestData(

--- a/mise.toml
+++ b/mise.toml
@@ -4,14 +4,18 @@
 # Usage: mise run <task>
 # List all tasks: mise tasks
 
+# Toolchain versions marked "sync:" are duplicated by setup-* steps in
+# .github/workflows/*.yml so CI reuses GitHub's prewarmed tool cache. Keep
+# both sides in step when bumping.
 [tools]
-dotnet = "10.0"
-go = "1.24"
+dotnet = "10.0"        # sync: actions/setup-dotnet in the workflows
+go = "1.26"
 golangci-lint = "latest"
-java = "temurin-11"
-node = "22"
-pnpm = "10"
-python = "3.13"
+java = "temurin-21"    # sync: actions/setup-java (Gradle 9 daemon JDK; jvmToolchain still targets 11)
+node = "22"            # sync: actions/setup-node in ci.yml (publish-npm pins 24 for npm OIDC)
+# npm backend: aqua's release-asset matching is unreliable for pnpm 11.x
+"npm:pnpm" = "11"
+python = "3.12"        # sync: actions/setup-python in the workflows
 ruff = "latest"
 rust = "stable"
 typst = "latest"
@@ -719,6 +723,9 @@ description = "Run documentation CI pipeline"
 run = [
     { task = "docs:clean" },
     { task = "docs:sync" },
+    # Fail CI if regeneration left uncommitted drift in tracked generated docs
+    # (per-language READMEs, width tables). Guards against shipping stale output.
+    "git diff --exit-code || { echo 'ERROR: docs:sync produced uncommitted drift — regenerate and commit generated docs' >&2; exit 1; }",
     { task = "pdf:build" },
     { task = "web:build" },
 ]

--- a/py/AGENTS.md
+++ b/py/AGENTS.md
@@ -128,9 +128,9 @@ Two-sample estimators check unit compatibility and convert to the finer unit.
 ```python
 from pragmastat import Sample, NUMBER_UNIT
 
-x = Sample([1, 2, 3, 4, 5])                          # unweighted, NUMBER_UNIT
-x = Sample([1, 2, 3], unit=NUMBER_UNIT)               # explicit unit
-x = Sample([1, 2, 3], weights=[0.5, 0.3, 0.2])       # weighted
+x = Sample([1, 2, 3, 4, 5])  # unweighted, NUMBER_UNIT
+x = Sample([1, 2, 3], unit=NUMBER_UNIT)  # explicit unit
+x = Sample([1, 2, 3], weights=[0.5, 0.3, 0.2])  # weighted
 ```
 
 Validation at construction time:

--- a/py/Dockerfile
+++ b/py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for Pragmastat Python implementation
-FROM python:3.10-slim
+FROM python:3.12-slim
 
 # Install build dependencies
 RUN apt-get update && \

--- a/py/pragmastat/_center_quantiles_impl.py
+++ b/py/pragmastat/_center_quantiles_impl.py
@@ -3,13 +3,11 @@
 Uses binary search with counting function to find exact quantiles in O(n log(range)) time.
 """
 
-from typing import List, Tuple
-
 # Relative epsilon for floating-point comparisons in binary search convergence.
 RELATIVE_EPSILON = 1e-14
 
 
-def _count_pairs_less_or_equal(sorted_vals: List[float], threshold: float) -> int:
+def _count_pairs_less_or_equal(sorted_vals: list[float], threshold: float) -> int:
     """
     Counts how many pairwise averages (sorted[i] + sorted[j])/2 where i <= j are <= threshold.
 
@@ -35,7 +33,7 @@ def _count_pairs_less_or_equal(sorted_vals: List[float], threshold: float) -> in
     return count
 
 
-def _find_exact_quantile(sorted_vals: List[float], k: int) -> float:
+def _find_exact_quantile(sorted_vals: list[float], k: int) -> float:
     """
     Finds the k-th smallest pairwise average using binary search.
 
@@ -75,7 +73,7 @@ def _find_exact_quantile(sorted_vals: List[float], k: int) -> float:
     target = 0.5 * lo + 0.5 * hi
 
     # Extract candidates that are close to the target
-    candidates: List[float] = []
+    candidates: list[float] = []
     for i in range(n):
         threshold = 2 * target - sorted_vals[i]
 
@@ -110,7 +108,7 @@ def _find_exact_quantile(sorted_vals: List[float], k: int) -> float:
     return target
 
 
-def center_quantile_bounds_impl(sorted_vals: List[float], k_lo: int, k_hi: int) -> Tuple[float, float]:
+def center_quantile_bounds_impl(sorted_vals: list[float], k_lo: int, k_hi: int) -> tuple[float, float]:
     """
     Finds both lower and upper quantile bounds for pairwise averages.
 

--- a/py/pragmastat/assumptions.py
+++ b/py/pragmastat/assumptions.py
@@ -14,13 +14,13 @@ is reported. For two-sample functions, subject X is checked before Y.
 """
 
 from dataclasses import dataclass
-from enum import Enum
+from enum import StrEnum
 from typing import Literal
 
 import numpy as np
 
 
-class AssumptionId(str, Enum):
+class AssumptionId(StrEnum):
     """Assumption identifiers in canonical priority order."""
 
     VALIDITY = "validity"

--- a/py/pragmastat/center_impl.py
+++ b/py/pragmastat/center_impl.py
@@ -4,7 +4,6 @@ Based on Monahan's Algorithm 616 (1984).
 """
 
 import struct
-from typing import List
 
 import numpy as np
 
@@ -19,7 +18,7 @@ except ImportError:
     _HAS_C_EXTENSION = False
 
 
-def _derive_seed(values: List[float]) -> int:
+def _derive_seed(values: list[float]) -> int:
     """Derive a deterministic seed from input values using FNV-1a hash."""
     FNV_OFFSET_BASIS = 0xCBF29CE484222325
     FNV_PRIME = 0x00000100000001B3
@@ -38,7 +37,7 @@ def _derive_seed(values: List[float]) -> int:
     return hash_val
 
 
-def _center_impl_python(values: List[float], assume_sorted: bool = False) -> float:
+def _center_impl_python(values: list[float], assume_sorted: bool = False) -> float:
     """
     Pure Python implementation of center estimator.
 

--- a/py/pragmastat/compare.py
+++ b/py/pragmastat/compare.py
@@ -277,7 +277,11 @@ def compare1(x: Sample, thresholds: list[Threshold], seed: str | None = None) ->
     results: list[Projection | None] = [None] * len(thresholds)
 
     for spec in _COMPARE1_SPECS:
-        entries = [(i, t, n) for i, (t, n) in enumerate(zip(thresholds, normalized_values)) if t.metric == spec.metric]
+        entries = [
+            (i, t, n)
+            for i, (t, n) in enumerate(zip(thresholds, normalized_values, strict=True))
+            if t.metric == spec.metric
+        ]
 
         if not entries:
             continue
@@ -338,7 +342,11 @@ def compare2(x: Sample, y: Sample, thresholds: list[Threshold], seed: str | None
     results: list[Projection | None] = [None] * len(thresholds)
 
     for spec in _COMPARE2_SPECS:
-        entries = [(i, t, n) for i, (t, n) in enumerate(zip(thresholds, normalized_values)) if t.metric == spec.metric]
+        entries = [
+            (i, t, n)
+            for i, (t, n) in enumerate(zip(thresholds, normalized_values, strict=True))
+            if t.metric == spec.metric
+        ]
 
         if not entries:
             continue

--- a/py/pragmastat/estimators.py
+++ b/py/pragmastat/estimators.py
@@ -42,7 +42,8 @@ array/sequence.
 from __future__ import annotations
 
 import math
-from typing import TYPE_CHECKING, Sequence, Union
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Union
 
 import numpy as np
 
@@ -309,7 +310,7 @@ def _spread_bounds_raw(
     return _spread_bounds_shuffle(x, m, misrate, rng)
 
 
-def _avg_spread_bounds_raw(  # noqa: PLR0913
+def _avg_spread_bounds_raw(  # noqa: PLR0913, PLR0917
     x: NDArray,
     sorted_x: NDArray | None,
     y: NDArray,
@@ -400,7 +401,7 @@ def _disparity_bounds_from_components(
     return -math.inf, math.inf
 
 
-def _disparity_bounds_raw(  # noqa: PLR0913
+def _disparity_bounds_raw(  # noqa: PLR0913, PLR0917
     x: NDArray,
     sorted_x: NDArray | None,
     y: NDArray,

--- a/py/pragmastat/pairwise_margin.py
+++ b/py/pragmastat/pairwise_margin.py
@@ -6,7 +6,6 @@ for small samples (n+m <= 400) and Edgeworth approximation for larger samples.
 """
 
 import math
-from typing import List
 
 from .assumptions import AssumptionError
 from .gauss_cdf import gauss_cdf as _gauss_cdf
@@ -71,8 +70,8 @@ def _pairwise_margin_exact_raw(n: int, m: int, p: float) -> int:
     else:
         total = _binomial_coefficient_float(n + m, m)
 
-    pmf: List[float] = [1.0]  # pmf[0] = 1
-    sigma: List[float] = [0.0]  # sigma[0] is unused
+    pmf: list[float] = [1.0]  # pmf[0] = 1
+    sigma: list[float] = [0.0]  # sigma[0] is unused
 
     u = 0
     cdf = 1.0 / total

--- a/py/pragmastat/rng.py
+++ b/py/pragmastat/rng.py
@@ -6,7 +6,8 @@ produces identical sequences across all Pragmastat language implementations.
 """
 
 import time
-from typing import List, Optional, Sequence, TypeVar, Union
+from collections.abc import Sequence
+from typing import TypeVar
 
 from .xoshiro256 import Xoshiro256PlusPlus, fnv1a_hash
 
@@ -35,7 +36,7 @@ class Rng:
     [3, 8, 9]
     """
 
-    def __init__(self, seed: Optional[Union[int, str]] = None) -> None:
+    def __init__(self, seed: int | str | None = None) -> None:
         """
         Create a new Rng.
 
@@ -149,7 +150,7 @@ class Rng:
         """
         return self._inner.uniform_bool()
 
-    def sample(self, x: Sequence[T], k: int) -> List[T]:
+    def sample(self, x: Sequence[T], k: int) -> list[T]:
         """
         Sample k elements from the input sequence without replacement.
 
@@ -187,7 +188,7 @@ class Rng:
         if k >= n:
             return list(x)
 
-        result: List[T] = []
+        result: list[T] = []
         remaining = k
 
         for i, item in enumerate(x):
@@ -201,7 +202,7 @@ class Rng:
 
         return result
 
-    def resample(self, x: Sequence[T], k: int) -> List[T]:
+    def resample(self, x: Sequence[T], k: int) -> list[T]:
         """
         Resample k elements from the input sequence with replacement.
 
@@ -230,13 +231,13 @@ class Rng:
         if n == 0:
             raise ValueError("resample: cannot resample from empty sequence")
 
-        result: List[T] = []
+        result: list[T] = []
         for _ in range(k):
             idx = self.uniform_int(0, n)
             result.append(x[idx])
         return result
 
-    def shuffle(self, x: Sequence[T]) -> List[T]:
+    def shuffle(self, x: Sequence[T]) -> list[T]:
         """
         Return a shuffled copy of the input sequence.
 

--- a/py/pragmastat/sample.py
+++ b/py/pragmastat/sample.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import cached_property
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -9,6 +9,8 @@ from .assumptions import AssumptionError, check_validity
 from .measurement_unit import NUMBER_UNIT, MeasurementUnit
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from numpy.typing import NDArray
 
 
@@ -172,7 +174,7 @@ class Sample:
         return self.__add__(-scalar)
 
 
-def _build_sample(  # noqa: PLR0913
+def _build_sample(  # noqa: PLR0913, PLR0917
     values: NDArray,
     unit: MeasurementUnit,
     is_weighted: bool,

--- a/py/pragmastat/shift_impl.py
+++ b/py/pragmastat/shift_impl.py
@@ -4,7 +4,7 @@ Computes quantiles of all pairwise differences without materializing them.
 Uses binary search in value space with two-pointer counting.
 """
 
-from typing import List, Sequence, Union
+from collections.abc import Sequence
 
 import numpy as np
 from numpy.typing import NDArray
@@ -24,7 +24,7 @@ def _midpoint(a: float, b: float) -> float:
     return 0.5 * a + 0.5 * b
 
 
-def _count_and_neighbors(x: List[float], y: List[float], threshold: float) -> tuple[int, float, float]:
+def _count_and_neighbors(x: list[float], y: list[float], threshold: float) -> tuple[int, float, float]:
     """
     Count pairs where x[i] - y[j] <= threshold using two-pointer algorithm.
 
@@ -71,7 +71,7 @@ def _count_and_neighbors(x: List[float], y: List[float], threshold: float) -> tu
     return count, max_below, min_above
 
 
-def _select_kth_pairwise_diff(x: List[float], y: List[float], k: int) -> float:
+def _select_kth_pairwise_diff(x: list[float], y: list[float], k: int) -> float:
     """
     Select the k-th smallest pairwise difference (1-indexed).
 
@@ -134,11 +134,11 @@ def _select_kth_pairwise_diff(x: List[float], y: List[float], k: int) -> float:
 
 
 def _shift_impl_python(
-    x: List[float],
-    y: List[float],
-    p: Union[float, List[float]] = 0.5,
+    x: list[float],
+    y: list[float],
+    p: float | list[float] = 0.5,
     assume_sorted: bool = False,
-) -> Union[float, List[float]]:
+) -> float | list[float]:
     """
     Pure Python implementation of shift estimator.
 
@@ -217,11 +217,11 @@ def _shift_impl_python(
 
 
 def _shift_impl(
-    x: Union[Sequence[float], NDArray],
-    y: Union[Sequence[float], NDArray],
-    p: Union[float, List[float]] = 0.5,
+    x: Sequence[float] | NDArray,
+    y: Sequence[float] | NDArray,
+    p: float | list[float] = 0.5,
     assume_sorted: bool = False,
-) -> Union[float, List[float]]:
+) -> float | list[float]:
     """
     Compute quantiles of all pairwise differences {x_i - y_j} efficiently.
 

--- a/py/pragmastat/spread_impl.py
+++ b/py/pragmastat/spread_impl.py
@@ -4,7 +4,6 @@ Based on Monahan's selection algorithm adapted for pairwise differences.
 """
 
 import struct
-from typing import List
 
 import numpy as np
 
@@ -19,7 +18,7 @@ except ImportError:
     _HAS_C_EXTENSION = False
 
 
-def _derive_seed(values: List[float]) -> int:
+def _derive_seed(values: list[float]) -> int:
     """Derive a deterministic seed from input values using FNV-1a hash."""
     FNV_OFFSET_BASIS = 0xCBF29CE484222325
     FNV_PRIME = 0x00000100000001B3
@@ -38,7 +37,7 @@ def _derive_seed(values: List[float]) -> int:
     return hash_val
 
 
-def _spread_impl_python(values: List[float], assume_sorted: bool = False) -> float:
+def _spread_impl_python(values: list[float], assume_sorted: bool = False) -> float:
     """
     Pure Python implementation of spread estimator.
 

--- a/py/pragmastat/xoshiro256.py
+++ b/py/pragmastat/xoshiro256.py
@@ -4,8 +4,6 @@ xoshiro256++ PRNG implementation for cross-language reproducibility.
 Reference: https://prng.di.unimi.it/xoshiro256plusplus.c
 """
 
-from typing import List
-
 # Mask for 64-bit unsigned operations
 U64_MASK = 0xFFFFFFFFFFFFFFFF
 
@@ -41,7 +39,7 @@ class Xoshiro256PlusPlus:
     def __init__(self, seed: int) -> None:
         """Create a new generator from a 64-bit seed."""
         sm = SplitMix64(seed)
-        self._state: List[int] = [sm.next(), sm.next(), sm.next(), sm.next()]
+        self._state: list[int] = [sm.next(), sm.next(), sm.next(), sm.next()]
 
     def next_u64(self) -> int:
         """Generate the next 64-bit random value."""

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -3,7 +3,7 @@ name = "pragmastat"
 version = "13.0.1"
 description = "Pragmastat: Pragmatic Statistical Toolkit"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Andrey Akinshin" }]
 dependencies = ["numpy>=1.20"]
@@ -20,7 +20,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.ruff]
 line-length = 120
-target-version = "py38"
+target-version = "py312"
 
 [tool.ruff.lint]
 select = ["ALL"]
@@ -31,9 +31,9 @@ ignore = [
     "D212",    # multi-line summary first line — project uses second-line style
     # Math/stats variable naming (x, y, n, m, p, etc.)
     "N806",    # non-lowercase-variable-in-function — math notation convention
-    # Python 3.8 compatibility (requires-python = ">=3.8")
-    "FA100",   # future-rewritable-type-annotation — py38 compat
-    "FA102",   # future-required-type-annotation — py38 compat
+    # Type-annotation style: don't mandate `from __future__ import annotations`
+    "FA100",   # future-rewritable-type-annotation
+    "FA102",   # future-required-type-annotation
     "UP015",   # redundant-open-modes — explicit is fine
     # Test-specific
     "S101",    # assert — used in tests
@@ -85,6 +85,8 @@ ignore = [
     "SIM108",  # if-else-block-instead-of-if-exp — explicit blocks preferred
     "ERA001",  # commented-out-code — occasional reference comments
     "RUF022",  # unsorted-dunder-all — __all__ grouped by category intentionally
+    # Copyright headers — project does not use them
+    "CPY001",  # missing-copyright-notice
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/py/tests/test_reference.py
+++ b/py/tests/test_reference.py
@@ -271,7 +271,7 @@ def run_distribution_tests(dist_name, dist_factory):
         actual = [dist.sample(rng) for _ in range(input_data["count"])]
 
         assert len(actual) == len(expected), f"Length mismatch for {json_file.name}: {len(actual)} vs {len(expected)}"
-        for i, (act, exp) in enumerate(zip(actual, expected)):
+        for i, (act, exp) in enumerate(zip(actual, expected, strict=True)):
             assert abs(act - exp) < 1e-12, f"Failed for {json_file.name}, index {i}: expected {exp}, got {act}"
 
 
@@ -360,7 +360,7 @@ class TestReference:
             assert len(actual) == len(expected), (
                 f"Length mismatch for {json_file.name}: {len(actual)} vs {len(expected)}"
             )
-            for i, (act, exp) in enumerate(zip(actual, expected)):
+            for i, (act, exp) in enumerate(zip(actual, expected, strict=True)):
                 assert abs(act - exp) < 1e-15, f"Failed for {json_file.name}, index {i}: expected {exp}, got {act}"
 
     def test_rng_uniform_int_reference(self):
@@ -408,7 +408,7 @@ class TestReference:
             assert len(actual) == len(expected), (
                 f"Length mismatch for {json_file.name}: {len(actual)} vs {len(expected)}"
             )
-            for i, (act, exp) in enumerate(zip(actual, expected)):
+            for i, (act, exp) in enumerate(zip(actual, expected, strict=True)):
                 assert abs(act - exp) < 1e-15, f"Failed for {json_file.name}, index {i}: expected {exp}, got {act}"
 
     def test_rng_uniform_float_range_reference(self):
@@ -435,7 +435,7 @@ class TestReference:
             assert len(actual) == len(expected), (
                 f"Length mismatch for {json_file.name}: {len(actual)} vs {len(expected)}"
             )
-            for i, (act, exp) in enumerate(zip(actual, expected)):
+            for i, (act, exp) in enumerate(zip(actual, expected, strict=True)):
                 assert abs(act - exp) < 1e-12, f"Failed for {json_file.name}, index {i}: expected {exp}, got {act}"
 
     def test_rng_uniform_bool_reference(self):
@@ -481,7 +481,7 @@ class TestReference:
             assert len(actual) == len(expected), (
                 f"Length mismatch for {json_file.name}: {len(actual)} vs {len(expected)}"
             )
-            for i, (act, exp) in enumerate(zip(actual, expected)):
+            for i, (act, exp) in enumerate(zip(actual, expected, strict=True)):
                 assert abs(act - exp) < 1e-15, f"Failed for {json_file.name}, index {i}: expected {exp}, got {act}"
 
     def test_sample_reference(self):
@@ -507,7 +507,7 @@ class TestReference:
             assert len(actual) == len(expected), (
                 f"Length mismatch for {json_file.name}: {len(actual)} vs {len(expected)}"
             )
-            for i, (act, exp) in enumerate(zip(actual, expected)):
+            for i, (act, exp) in enumerate(zip(actual, expected, strict=True)):
                 assert abs(act - exp) < 1e-15, f"Failed for {json_file.name}, index {i}: expected {exp}, got {act}"
 
     def test_resample_reference(self):
@@ -533,7 +533,7 @@ class TestReference:
             assert len(actual) == len(expected), (
                 f"Length mismatch for {json_file.name}: {len(actual)} vs {len(expected)}"
             )
-            for i, (act, exp) in enumerate(zip(actual, expected)):
+            for i, (act, exp) in enumerate(zip(actual, expected, strict=True)):
                 assert abs(act - exp) < 1e-15, f"Failed for {json_file.name}, index {i}: expected {exp}, got {act}"
 
     def test_uniform_distribution_reference(self):
@@ -928,7 +928,7 @@ class TestCompare1:
                 f"Projection count mismatch for {json_file.name}: {len(projections)} vs {len(expected_projections)}"
             )
 
-            for i, (actual, expected) in enumerate(zip(projections, expected_projections)):
+            for i, (actual, expected) in enumerate(zip(projections, expected_projections, strict=True)):
                 context = f" for {json_file.name}, projection {i}"
                 assert abs(actual.estimate.value - expected["estimate"]) < 1e-9, (
                     f"Estimate mismatch{context}: expected {expected['estimate']}, got {actual.estimate.value}"
@@ -1011,7 +1011,7 @@ class TestCompare2:
                 f"Projection count mismatch for {json_file.name}: {len(projections)} vs {len(expected_projections)}"
             )
 
-            for i, (actual, expected) in enumerate(zip(projections, expected_projections)):
+            for i, (actual, expected) in enumerate(zip(projections, expected_projections, strict=True)):
                 context = f" for {json_file.name}, projection {i}"
                 assert abs(actual.estimate.value - expected["estimate"]) < 1e-9, (
                     f"Estimate mismatch{context}: expected {expected['estimate']}, got {actual.estimate.value}"

--- a/r/Dockerfile
+++ b/r/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile for Pragmastat R implementation
 # Note: rocker/verse doesn't support ARM64. On Apple Silicon, this runs via x86_64 emulation (Rosetta 2)
 # The platform is specified in docker-compose.yml as linux/amd64
-FROM rocker/verse:latest
+FROM rocker/verse:4.6.1
 
 # Update TeX Live packages
 RUN tlmgr update --self && \

--- a/rs/Dockerfile
+++ b/rs/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for Pragmastat Rust implementation
-FROM rust:1.90-slim
+FROM rust:1-slim
 
 # Install additional components
 RUN rustup component add rustfmt clippy

--- a/rs/pragmastat-sim/Cargo.toml
+++ b/rs/pragmastat-sim/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pragmastat-sim"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 [dependencies]

--- a/rs/pragmastat-sim/src/runner.rs
+++ b/rs/pragmastat-sim/src/runner.rs
@@ -1,6 +1,6 @@
 use crate::output::OutputWriter;
 use crate::progress::ProgressTracker;
-use crate::sim::{output_path, SimError, Simulation, SimulationRow};
+use crate::sim::{SimError, Simulation, SimulationRow, output_path};
 use console::style;
 use rayon::prelude::*;
 use std::collections::BTreeMap;

--- a/rs/pragmastat-sim/src/sim/avg_drift.rs
+++ b/rs/pragmastat-sim/src/sim/avg_drift.rs
@@ -1,4 +1,4 @@
-use super::drift::{format_drift_row, round_drift_row, DriftInput, DriftRow};
+use super::drift::{DriftInput, DriftRow, format_drift_row, round_drift_row};
 use super::{SimError, Simulation};
 use crate::distributions::{self, DistributionEntry};
 use crate::estimators;
@@ -61,11 +61,9 @@ impl Simulation for AvgDriftSim {
         for dist in &self.distributions {
             for &n in sample_sizes {
                 let key = format!("{}-{}", dist.name, n);
-                if !overwrite {
-                    if let Some(row) = existing.get(&key) {
-                        reused.push(row.clone());
-                        continue;
-                    }
+                if !overwrite && let Some(row) = existing.get(&key) {
+                    reused.push(row.clone());
+                    continue;
                 }
                 inputs.push(DriftInput {
                     distribution_name: dist.name.to_string(),

--- a/rs/pragmastat-sim/src/sim/avg_spread_bounds.rs
+++ b/rs/pragmastat-sim/src/sim/avg_spread_bounds.rs
@@ -1,9 +1,10 @@
 use super::bounds::{
-    format_two_sample_bounds_row, min_achievable_misrate_avg_spread, parse_misrates,
-    resolve_sample_count, round_two_sample_bounds_row, TwoSampleBoundsInput, TwoSampleBoundsRow,
+    TwoSampleBoundsInput, TwoSampleBoundsRow, format_two_sample_bounds_row,
+    min_achievable_misrate_avg_spread, parse_misrates, resolve_sample_count,
+    round_two_sample_bounds_row,
 };
 use super::{SimError, Simulation};
-use crate::distributions::{asymptotic_spread, find_distributions, DistributionEntry};
+use crate::distributions::{DistributionEntry, asymptotic_spread, find_distributions};
 use pragmastat::Rng;
 use std::collections::BTreeMap;
 
@@ -63,11 +64,9 @@ impl Simulation for AvgSpreadBoundsSim {
                             continue;
                         }
                         let key = format!("{}-{}-{}-{}", dist.name, n, m, misrate);
-                        if !overwrite {
-                            if let Some(row) = existing.get(&key) {
-                                reused.push(row.clone());
-                                continue;
-                            }
+                        if !overwrite && let Some(row) = existing.get(&key) {
+                            reused.push(row.clone());
+                            continue;
                         }
                         inputs.push(TwoSampleBoundsInput {
                             distribution_name: dist.name.to_string(),

--- a/rs/pragmastat-sim/src/sim/bounds.rs
+++ b/rs/pragmastat-sim/src/sim/bounds.rs
@@ -91,11 +91,7 @@ pub fn parse_misrates(input: &str) -> Vec<f64> {
                 return None;
             }
             let v: f64 = trimmed.parse().ok()?;
-            if v > 0.0 && v < 1.0 {
-                Some(v)
-            } else {
-                None
-            }
+            if v > 0.0 && v < 1.0 { Some(v) } else { None }
         })
         .collect()
 }

--- a/rs/pragmastat-sim/src/sim/center_bounds.rs
+++ b/rs/pragmastat-sim/src/sim/center_bounds.rs
@@ -1,9 +1,9 @@
 use super::bounds::{
-    format_bounds_row, min_achievable_misrate_one_sample, parse_misrates, resolve_sample_count,
-    round_bounds_row, BoundsInput, BoundsRow,
+    BoundsInput, BoundsRow, format_bounds_row, min_achievable_misrate_one_sample, parse_misrates,
+    resolve_sample_count, round_bounds_row,
 };
 use super::{SimError, Simulation};
-use crate::distributions::{find_distributions, DistributionEntry};
+use crate::distributions::{DistributionEntry, find_distributions};
 use pragmastat::Rng;
 use std::collections::BTreeMap;
 
@@ -58,11 +58,9 @@ impl Simulation for CenterBoundsSim {
                         continue;
                     }
                     let key = format!("{}-{}-{}", dist.name, n, misrate);
-                    if !overwrite {
-                        if let Some(row) = existing.get(&key) {
-                            reused.push(row.clone());
-                            continue;
-                        }
+                    if !overwrite && let Some(row) = existing.get(&key) {
+                        reused.push(row.clone());
+                        continue;
                     }
                     inputs.push(BoundsInput {
                         distribution_name: dist.name.to_string(),

--- a/rs/pragmastat-sim/src/sim/disp_drift.rs
+++ b/rs/pragmastat-sim/src/sim/disp_drift.rs
@@ -1,4 +1,4 @@
-use super::drift::{format_drift_row, round_drift_row, DriftInput, DriftRow};
+use super::drift::{DriftInput, DriftRow, format_drift_row, round_drift_row};
 use super::{SimError, Simulation};
 use crate::distributions::{self, DistributionEntry};
 use crate::estimators;
@@ -61,11 +61,9 @@ impl Simulation for DispDriftSim {
         for dist in &self.distributions {
             for &n in sample_sizes {
                 let key = format!("{}-{}", dist.name, n);
-                if !overwrite {
-                    if let Some(row) = existing.get(&key) {
-                        reused.push(row.clone());
-                        continue;
-                    }
+                if !overwrite && let Some(row) = existing.get(&key) {
+                    reused.push(row.clone());
+                    continue;
                 }
                 inputs.push(DriftInput {
                     distribution_name: dist.name.to_string(),

--- a/rs/pragmastat-sim/src/sim/disparity_bounds.rs
+++ b/rs/pragmastat-sim/src/sim/disparity_bounds.rs
@@ -1,6 +1,6 @@
 use super::bounds::{
-    format_bounds_row, min_achievable_misrate_disparity, parse_misrates, resolve_sample_count,
-    round_bounds_row, BoundsInput, BoundsRow,
+    BoundsInput, BoundsRow, format_bounds_row, min_achievable_misrate_disparity, parse_misrates,
+    resolve_sample_count, round_bounds_row,
 };
 use super::{SimError, Simulation};
 use crate::distributions::{self, DistributionEntry};
@@ -55,11 +55,9 @@ impl Simulation for DisparityBoundsSim {
                         continue;
                     }
                     let key = format!("{}-{}-{}", dist.name, n, misrate);
-                    if !overwrite {
-                        if let Some(row) = existing.get(&key) {
-                            reused.push(row.clone());
-                            continue;
-                        }
+                    if !overwrite && let Some(row) = existing.get(&key) {
+                        reused.push(row.clone());
+                        continue;
                     }
                     inputs.push(BoundsInput {
                         distribution_name: dist.name.to_string(),

--- a/rs/pragmastat-sim/src/sim/ratio_bounds.rs
+++ b/rs/pragmastat-sim/src/sim/ratio_bounds.rs
@@ -1,6 +1,6 @@
 use super::bounds::{
-    format_bounds_row, min_achievable_misrate_two_sample, parse_misrates, resolve_sample_count,
-    round_bounds_row, BoundsInput, BoundsRow,
+    BoundsInput, BoundsRow, format_bounds_row, min_achievable_misrate_two_sample, parse_misrates,
+    resolve_sample_count, round_bounds_row,
 };
 use super::{SimError, Simulation};
 use crate::distributions::{self, DistributionEntry};
@@ -58,11 +58,9 @@ impl Simulation for RatioBoundsSim {
                         continue;
                     }
                     let key = format!("{}-{}-{}", dist.name, n, misrate);
-                    if !overwrite {
-                        if let Some(row) = existing.get(&key) {
-                            reused.push(row.clone());
-                            continue;
-                        }
+                    if !overwrite && let Some(row) = existing.get(&key) {
+                        reused.push(row.clone());
+                        continue;
                     }
                     inputs.push(BoundsInput {
                         distribution_name: dist.name.to_string(),

--- a/rs/pragmastat-sim/src/sim/shift_bounds.rs
+++ b/rs/pragmastat-sim/src/sim/shift_bounds.rs
@@ -1,6 +1,6 @@
 use super::bounds::{
-    format_bounds_row, min_achievable_misrate_two_sample, parse_misrates, resolve_sample_count,
-    round_bounds_row, BoundsInput, BoundsRow,
+    BoundsInput, BoundsRow, format_bounds_row, min_achievable_misrate_two_sample, parse_misrates,
+    resolve_sample_count, round_bounds_row,
 };
 use super::{SimError, Simulation};
 use crate::distributions::{self, DistributionEntry};
@@ -55,11 +55,9 @@ impl Simulation for ShiftBoundsSim {
                         continue;
                     }
                     let key = format!("{}-{}-{}", dist.name, n, misrate);
-                    if !overwrite {
-                        if let Some(row) = existing.get(&key) {
-                            reused.push(row.clone());
-                            continue;
-                        }
+                    if !overwrite && let Some(row) = existing.get(&key) {
+                        reused.push(row.clone());
+                        continue;
                     }
                     inputs.push(BoundsInput {
                         distribution_name: dist.name.to_string(),

--- a/rs/pragmastat-sim/src/sim/spread_bounds.rs
+++ b/rs/pragmastat-sim/src/sim/spread_bounds.rs
@@ -1,9 +1,9 @@
 use super::bounds::{
-    format_bounds_row, min_achievable_misrate_spread, parse_misrates, resolve_sample_count,
-    round_bounds_row, BoundsInput, BoundsRow,
+    BoundsInput, BoundsRow, format_bounds_row, min_achievable_misrate_spread, parse_misrates,
+    resolve_sample_count, round_bounds_row,
 };
 use super::{SimError, Simulation};
-use crate::distributions::{asymptotic_spread, find_distributions, DistributionEntry};
+use crate::distributions::{DistributionEntry, asymptotic_spread, find_distributions};
 use pragmastat::Rng;
 use std::collections::BTreeMap;
 
@@ -55,11 +55,9 @@ impl Simulation for SpreadBoundsSim {
                         continue;
                     }
                     let key = format!("{}-{}-{}", dist.name, n, misrate);
-                    if !overwrite {
-                        if let Some(row) = existing.get(&key) {
-                            reused.push(row.clone());
-                            continue;
-                        }
+                    if !overwrite && let Some(row) = existing.get(&key) {
+                        reused.push(row.clone());
+                        continue;
                     }
                     inputs.push(BoundsInput {
                         distribution_name: dist.name.to_string(),

--- a/rs/pragmastat/Cargo.toml
+++ b/rs/pragmastat/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "pragmastat"
 version = "13.0.1"
-edition = "2021"
+edition = "2024"
+rust-version = "1.87"
 authors = ["Andrey Akinshin"]
 description = "Pragmastat: Pragmatic Statistical Toolkit"
 license = "MIT"

--- a/rs/pragmastat/examples/gen_rng_tests.rs
+++ b/rs/pragmastat/examples/gen_rng_tests.rs
@@ -5,8 +5,8 @@
 //! This generates JSON test files in the tests/ directory that all language
 //! implementations must pass to ensure cross-language consistency.
 
-use pragmastat::distributions::{Additive, Distribution, Exp, Multiplic, Power, Uniform};
 use pragmastat::Rng;
+use pragmastat::distributions::{Additive, Distribution, Exp, Multiplic, Power, Uniform};
 use serde::Serialize;
 use std::fs;
 use std::path::PathBuf;

--- a/rs/pragmastat/src/center_quantiles_impl.rs
+++ b/rs/pragmastat/src/center_quantiles_impl.rs
@@ -21,11 +21,7 @@ pub fn center_quantile_bounds_impl(sorted: &[f64], margin_lo: i64, margin_hi: i6
     let lo = center_find_exact_quantile_impl(sorted, margin_lo);
     let hi = center_find_exact_quantile_impl(sorted, margin_hi);
 
-    if lo > hi {
-        (hi, lo)
-    } else {
-        (lo, hi)
-    }
+    if lo > hi { (hi, lo) } else { (lo, hi) }
 }
 
 /// Count pairwise averages <= target value.

--- a/rs/pragmastat/src/compare.rs
+++ b/rs/pragmastat/src/compare.rs
@@ -8,9 +8,9 @@ use crate::bounds::Bounds;
 use crate::estimators;
 use crate::measurement::Measurement;
 use crate::measurement_unit::{
-    conversion_factor, finer, is_compatible, MeasurementUnit, UnitMismatchError,
+    MeasurementUnit, UnitMismatchError, conversion_factor, finer, is_compatible,
 };
-use crate::sample::{check_compatible_units, check_non_weighted, Sample};
+use crate::sample::{Sample, check_compatible_units, check_non_weighted};
 
 /// Metric types supported by Compare1 and Compare2.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -638,12 +638,14 @@ mod tests {
 
     #[test]
     fn test_threshold_non_finite_value() {
-        assert!(Threshold::new(
-            Metric::Center,
-            Measurement::new(f64::INFINITY, MeasurementUnit::number()),
-            0.1,
-        )
-        .is_err());
+        assert!(
+            Threshold::new(
+                Metric::Center,
+                Measurement::new(f64::INFINITY, MeasurementUnit::number()),
+                0.1,
+            )
+            .is_err()
+        );
     }
 
     #[test]

--- a/rs/pragmastat/src/estimators.rs
+++ b/rs/pragmastat/src/estimators.rs
@@ -5,12 +5,12 @@
 //! lightweight numeric interface and for internal tests.
 
 use crate::assumptions::{
-    check_positivity, check_validity, log, AssumptionError, EstimatorError, Subject,
+    AssumptionError, EstimatorError, Subject, check_positivity, check_validity, log,
 };
 use crate::bounds::Bounds;
 use crate::measurement::Measurement;
 use crate::measurement_unit::MeasurementUnit;
-use crate::sample::{check_non_weighted, prepare_pair, Sample};
+use crate::sample::{Sample, check_non_weighted, prepare_pair};
 
 /// Default misclassification rate for bounds estimators.
 pub const DEFAULT_MISRATE: f64 = 1e-3;
@@ -312,11 +312,7 @@ pub mod raw {
     /// The disjoint-pair shuffle always runs on the caller's slice regardless,
     /// so on a genuinely sorted slice the flag never changes the result.
     fn sorted_view(x: &[f64], assume_sorted: bool) -> Option<&[f64]> {
-        if assume_sorted {
-            Some(x)
-        } else {
-            None
-        }
+        if assume_sorted { Some(x) } else { None }
     }
 
     /// Computes weighted-average spread bounds.

--- a/rs/pragmastat/src/lib.rs
+++ b/rs/pragmastat/src/lib.rs
@@ -50,18 +50,18 @@ mod signed_rank_margin_tests;
 pub use assumptions::{AssumptionError, AssumptionId, EstimatorError, Subject, Violation};
 pub use bounds::Bounds;
 pub use compare::{
-    compare1, compare1_with_seed, compare2, compare2_with_seed, ComparisonVerdict, Metric,
-    Projection, Threshold,
+    ComparisonVerdict, Metric, Projection, Threshold, compare1, compare1_with_seed, compare2,
+    compare2_with_seed,
 };
 pub use distributions::{Additive, Distribution, Exp, Multiplic, Power, Uniform};
 pub use estimators::{
-    center, center_bounds, disparity, disparity_bounds, disparity_bounds_with_seed, ratio,
-    ratio_bounds, shift, shift_bounds, spread, spread_bounds, spread_bounds_with_seed,
-    DEFAULT_MISRATE,
+    DEFAULT_MISRATE, center, center_bounds, disparity, disparity_bounds,
+    disparity_bounds_with_seed, ratio, ratio_bounds, shift, shift_bounds, spread, spread_bounds,
+    spread_bounds_with_seed,
 };
 pub use measurement::Measurement;
 pub use measurement_unit::{
-    conversion_factor, finer, is_compatible, MeasurementUnit, UnitMismatchError,
+    MeasurementUnit, UnitMismatchError, conversion_factor, finer, is_compatible,
 };
 pub use rng::Rng;
 pub use sample::Sample;

--- a/rs/pragmastat/src/sample.rs
+++ b/rs/pragmastat/src/sample.rs
@@ -6,7 +6,7 @@
 
 use crate::assumptions::{AssumptionError, EstimatorError, Subject};
 use crate::measurement_unit::{
-    conversion_factor, finer, is_compatible, MeasurementUnit, UnitMismatchError,
+    MeasurementUnit, UnitMismatchError, conversion_factor, finer, is_compatible,
 };
 use std::ops::Mul;
 use std::sync::OnceLock;

--- a/rs/pragmastat/src/shift_impl.rs
+++ b/rs/pragmastat/src/shift_impl.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use crate::assumptions::{log, Subject};
+use crate::assumptions::{Subject, log};
 
 /// Computes quantiles of all pairwise differences {x[i] - y[j]}.
 /// Time complexity: O((m+n) log precision) per unique rank.

--- a/rs/pragmastat/tests/compare_tests.rs
+++ b/rs/pragmastat/tests/compare_tests.rs
@@ -6,8 +6,8 @@
 use float_cmp::approx_eq;
 use pragmastat::assumptions::EstimatorError;
 use pragmastat::compare::{
-    compare1, compare1_with_seed, compare2, compare2_with_seed, ComparisonVerdict, Metric,
-    Threshold,
+    ComparisonVerdict, Metric, Threshold, compare1, compare1_with_seed, compare2,
+    compare2_with_seed,
 };
 use pragmastat::measurement::Measurement;
 use pragmastat::sample::Sample;

--- a/rs/pragmastat/tests/sample_bounds_consistency_tests.rs
+++ b/rs/pragmastat/tests/sample_bounds_consistency_tests.rs
@@ -14,7 +14,7 @@
 //! These tests lock the Sample API to the raw API directly.
 
 use pragmastat::estimators::raw;
-use pragmastat::{disparity_bounds_with_seed, spread_bounds_with_seed, Sample};
+use pragmastat::{Sample, disparity_bounds_with_seed, spread_bounds_with_seed};
 
 const UNSORTED_X: [f64; 20] = [
     5.0, 3.0, 1.0, 4.0, 2.0, 9.0, 7.0, 6.0, 8.0, 10.0, 15.0, 11.0, 13.0, 12.0, 14.0, 20.0, 18.0,

--- a/ts/Dockerfile
+++ b/ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for Pragmastat TypeScript implementation
-FROM node:20-alpine
+FROM node:22-alpine
 
 # Install bash for build scripts
 RUN apk add --no-cache bash
@@ -7,14 +7,14 @@ RUN apk add --no-cache bash
 # Set working directory to ts
 WORKDIR /workspace/ts
 
-# Set npm cache to a writable directory for non-root users
-ENV npm_config_cache=/tmp/.npm
+# Non-interactive install (pnpm 11 skips the modules-purge confirmation)
+ENV CI=true
 
-# Copy only package files
-COPY ts/package.json ts/package-lock.json ./
+# Copy only package files (the project uses pnpm, not npm)
+COPY ts/package.json ts/pnpm-lock.yaml ./
 
 # Install dependencies (cached in Docker layer)
-RUN npm ci
+RUN npm install -g pnpm@11 && pnpm install --frozen-lockfile
 
 # Note: Source code will be mounted via volume at runtime
 # This ensures dependencies are cached but source is always fresh

--- a/ts/package.json
+++ b/ts/package.json
@@ -26,9 +26,12 @@
   ],
   "author": "Andrey Akinshin",
   "license": "MIT",
+  "engines": {
+    "node": ">=22"
+  },
   "devDependencies": {
     "@types/jest": "^29.5.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "eslint": "^9.0.0",
@@ -36,7 +39,7 @@
     "prettier": "^3.0.0",
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.2",
-    "typescript": "^5.0.0"
+    "typescript": "^5.9.0"
   },
   "files": [
     "dist",

--- a/ts/pnpm-lock.yaml
+++ b/ts/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^29.5.0
         version: 29.5.14
       '@types/node':
-        specifier: ^20.0.0
-        version: 20.19.30
+        specifier: ^22.0.0
+        version: 22.20.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.0.0
         version: 8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3)
@@ -25,18 +25,18 @@ importers:
         version: 9.39.2
       jest:
         specifier: ^29.5.0
-        version: 29.7.0(@types/node@20.19.30)(ts-node@10.9.2(@types/node@20.19.30)(typescript@5.9.3))
+        version: 29.7.0(@types/node@22.20.0)(ts-node@10.9.2(@types/node@22.20.0)(typescript@5.9.3))
       prettier:
         specifier: ^3.0.0
         version: 3.8.1
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.30)(ts-node@10.9.2(@types/node@20.19.30)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.20.0)(ts-node@10.9.2(@types/node@22.20.0)(typescript@5.9.3)))(typescript@5.9.3)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@20.19.30)(typescript@5.9.3)
+        version: 10.9.2(@types/node@22.20.0)(typescript@5.9.3)
       typescript:
-        specifier: ^5.0.0
+        specifier: ^5.9.0
         version: 5.9.3
 
 packages:
@@ -411,8 +411,8 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/node@20.19.30':
-    resolution: {integrity: sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==}
+  '@types/node@22.20.0':
+    resolution: {integrity: sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -848,7 +848,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -1837,27 +1837,27 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.19.30
+      '@types/node': 22.20.0
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@20.19.30)(typescript@5.9.3))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.20.0)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.30
+      '@types/node': 22.20.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.19.30)(ts-node@10.9.2(@types/node@20.19.30)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@22.20.0)(ts-node@10.9.2(@types/node@22.20.0)(typescript@5.9.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -1882,7 +1882,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.30
+      '@types/node': 22.20.0
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -1900,7 +1900,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 20.19.30
+      '@types/node': 22.20.0
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -1922,7 +1922,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 20.19.30
+      '@types/node': 22.20.0
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit: 0.1.2
@@ -1992,7 +1992,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.19.30
+      '@types/node': 22.20.0
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -2063,7 +2063,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 20.19.30
+      '@types/node': 22.20.0
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -2082,7 +2082,7 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/node@20.19.30':
+  '@types/node@22.20.0':
     dependencies:
       undici-types: 6.21.0
 
@@ -2356,13 +2356,13 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  create-jest@29.7.0(@types/node@20.19.30)(ts-node@10.9.2(@types/node@20.19.30)(typescript@5.9.3)):
+  create-jest@29.7.0(@types/node@22.20.0)(ts-node@10.9.2(@types/node@22.20.0)(typescript@5.9.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.19.30)(ts-node@10.9.2(@types/node@20.19.30)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@22.20.0)(ts-node@10.9.2(@types/node@22.20.0)(typescript@5.9.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -2689,7 +2689,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.30
+      '@types/node': 22.20.0
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.1
@@ -2709,16 +2709,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.19.30)(ts-node@10.9.2(@types/node@20.19.30)(typescript@5.9.3)):
+  jest-cli@29.7.0(@types/node@22.20.0)(ts-node@10.9.2(@types/node@22.20.0)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.19.30)(typescript@5.9.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.20.0)(typescript@5.9.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.19.30)(ts-node@10.9.2(@types/node@20.19.30)(typescript@5.9.3))
+      create-jest: 29.7.0(@types/node@22.20.0)(ts-node@10.9.2(@types/node@22.20.0)(typescript@5.9.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@20.19.30)(ts-node@10.9.2(@types/node@20.19.30)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@22.20.0)(ts-node@10.9.2(@types/node@22.20.0)(typescript@5.9.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -2728,7 +2728,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@20.19.30)(ts-node@10.9.2(@types/node@20.19.30)(typescript@5.9.3)):
+  jest-config@29.7.0(@types/node@22.20.0)(ts-node@10.9.2(@types/node@22.20.0)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/test-sequencer': 29.7.0
@@ -2753,8 +2753,8 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 20.19.30
-      ts-node: 10.9.2(@types/node@20.19.30)(typescript@5.9.3)
+      '@types/node': 22.20.0
+      ts-node: 10.9.2(@types/node@22.20.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -2783,7 +2783,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.30
+      '@types/node': 22.20.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -2793,7 +2793,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 20.19.30
+      '@types/node': 22.20.0
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -2832,7 +2832,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.19.30
+      '@types/node': 22.20.0
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -2867,7 +2867,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.30
+      '@types/node': 22.20.0
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -2895,7 +2895,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.30
+      '@types/node': 22.20.0
       chalk: 4.1.2
       cjs-module-lexer: 1.4.3
       collect-v8-coverage: 1.0.3
@@ -2941,7 +2941,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.19.30
+      '@types/node': 22.20.0
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -2960,7 +2960,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.30
+      '@types/node': 22.20.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -2969,17 +2969,17 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 20.19.30
+      '@types/node': 22.20.0
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@20.19.30)(ts-node@10.9.2(@types/node@20.19.30)(typescript@5.9.3)):
+  jest@29.7.0(@types/node@22.20.0)(ts-node@10.9.2(@types/node@22.20.0)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.19.30)(typescript@5.9.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.20.0)(typescript@5.9.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@20.19.30)(ts-node@10.9.2(@types/node@20.19.30)(typescript@5.9.3))
+      jest-cli: 29.7.0(@types/node@22.20.0)(ts-node@10.9.2(@types/node@22.20.0)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -3271,12 +3271,12 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.30)(ts-node@10.9.2(@types/node@20.19.30)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.20.0)(ts-node@10.9.2(@types/node@22.20.0)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.8
-      jest: 29.7.0(@types/node@20.19.30)(ts-node@10.9.2(@types/node@20.19.30)(typescript@5.9.3))
+      jest: 29.7.0(@types/node@22.20.0)(ts-node@10.9.2(@types/node@22.20.0)(typescript@5.9.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -3291,14 +3291,14 @@ snapshots:
       babel-jest: 29.7.0(@babel/core@7.29.0)
       jest-util: 29.7.0
 
-  ts-node@10.9.2(@types/node@20.19.30)(typescript@5.9.3):
+  ts-node@10.9.2(@types/node@22.20.0)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 20.19.30
+      '@types/node': 22.20.0
       acorn: 8.15.0
       acorn-walk: 8.3.5
       arg: 4.1.3

--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2023",
     "module": "commonjs",
-    "lib": ["ES2020"],
+    "lib": ["ES2023"],
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,

--- a/web/package.json
+++ b/web/package.json
@@ -17,11 +17,5 @@
   "devDependencies": {
     "rehype-katex": "^7.0.0",
     "remark-math": "^6.0.0"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "sharp"
-    ]
   }
 }

--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+# pnpm 11 moved build-script settings out of package.json's "pnpm" field.
+# Allow the native postinstall builds these packages need.
+allowBuilds:
+  esbuild: true
+  sharp: true


### PR DESCRIPTION
Raises the runtime floor and modernizes tooling across all seven language implementations ahead of the 14.0.0 major: Python 3.12, Go 1.25, Rust edition 2024, a net10.0 target for .NET (net6.0 retained for BenchmarkDotNet), a refreshed Kotlin/JDK/Gradle stack, and TypeScript on ES2023 with a Node 22 floor and pnpm 11. CI setup steps, Docker base images, and mise pins are kept in sync in both directions, and Dependabot is added to track dependencies going forward.

## Appendix

Commits (oldest first): py 3.12 floor, go 1.25 floor, cs net10.0 target + drop obsolete serialization ctor, rs edition 2024, ts ES2023/Node22/pnpm11, kt stack bump, mise pin + CI sync, docker base images, Dependabot.