### PR TITLE
Fix cross-language correctness bugs and demonstrate confirmatory comparison

### DIFF
--- a/cs/Pragmastat.Demo/Program.cs
+++ b/cs/Pragmastat.Demo/Program.cs
@@ -1,5 +1,6 @@
 using static System.Console;
 using Pragmastat.Distributions;
+using Pragmastat.Metrology;
 using Pragmastat.Randomization;
 
 namespace Pragmastat.Demo;
@@ -28,6 +29,11 @@ class Program
     WriteLine(x.RatioBounds(y));                  // [0.4066666666666668;0.5958333333333332]
     WriteLine(x.Disparity(y));                    // -1.694915254237288
     WriteLine(x.DisparityBounds(y, 1e-3, "demo")); // [-3.1025641025641026;-0.8494623655913979]
+
+    // --- Confirmatory Comparison ---
+
+    WriteLine(Toolkit.Compare1(x, [new Threshold(Metric.Center, new Measurement(50, MeasurementUnit.Number), 1e-3)])[0].Verdict.ToId()); // greater
+    WriteLine(Toolkit.Compare2(x, y, [new Threshold(Metric.Shift, new Measurement(0, MeasurementUnit.Number), 1e-3)])[0].Verdict.ToId()); // less
 
     // --- Randomization ---
 

--- a/cs/Pragmastat.Tests/Algorithms/CenterImplConvergenceTests.cs
+++ b/cs/Pragmastat.Tests/Algorithms/CenterImplConvergenceTests.cs
@@ -17,13 +17,12 @@ public class CenterImplConvergenceTests
   {
     // Adversarial unsorted input. With assumeSorted=true the algorithm's sorted-matrix
     // invariants are violated, so the selection loop cannot make consistent progress.
-    // Deterministic RNG keeps the test reproducible.
+    // The impl seeds its RNG deterministically from the input, so this is reproducible.
     var values = new double[] { 5, 1, 9, 2, 8, 3, 7, 4, 6, 0, 5, 1, 9, 2, 8, 3, 7, 4, 6, 0 };
-    var rng = new Random(12345);
 
     var stopwatch = Stopwatch.StartNew();
     var ex = Assert.Throws<InvalidOperationException>(() =>
-      CenterImpl.Estimate(values, rng, assumeSorted: true));
+      CenterImpl.Estimate(values, assumeSorted: true));
     stopwatch.Stop();
 
     Assert.Contains("Convergence failure", ex.Message);
@@ -38,7 +37,7 @@ public class CenterImplConvergenceTests
   {
     // Sanity: the cap must never trigger on valid sorted input.
     var values = Enumerable.Range(1, 1000).Select(i => (double)i).ToArray();
-    double result = CenterImpl.Estimate(values, new Random(1), assumeSorted: true);
+    double result = CenterImpl.Estimate(values, assumeSorted: true);
     Assert.Equal(500.5, result, 1e-9);
   }
 }

--- a/cs/Pragmastat.Tests/Algorithms/SpreadImplConvergenceTests.cs
+++ b/cs/Pragmastat.Tests/Algorithms/SpreadImplConvergenceTests.cs
@@ -20,11 +20,10 @@ public class SpreadImplConvergenceTests
     // partition invariants are violated; the selection loop never reaches the target rank and
     // cannot make consistent progress. Deterministic RNG keeps the test reproducible.
     var values = new double[] { 5, 5, 4, 4, 3, 3, 2, 2, 1, 1 };
-    var rng = new Random(1);
 
     var stopwatch = Stopwatch.StartNew();
     var ex = Assert.Throws<InvalidOperationException>(() =>
-      SpreadImpl.Estimate(values, rng, assumeSorted: true));
+      SpreadImpl.Estimate(values, assumeSorted: true));
     stopwatch.Stop();
 
     Assert.Contains("Convergence failure", ex.Message);
@@ -39,7 +38,7 @@ public class SpreadImplConvergenceTests
   {
     // Sanity: the cap must never trigger on valid sorted input.
     var values = Enumerable.Range(1, 1000).Select(i => (double)i).ToArray();
-    double result = SpreadImpl.Estimate(values, new Random(1), assumeSorted: true);
+    double result = SpreadImpl.Estimate(values, assumeSorted: true);
     // Shamos spread of 1..1000 is the median of the 499500 pairwise gaps. Gap d occurs
     // (1000 - d) times, so ranks 249750 and 249751 both land on d = 293.
     Assert.Equal(293.0, result, 1e-9);

--- a/cs/Pragmastat.Tests/ShiftOverflowTests.cs
+++ b/cs/Pragmastat.Tests/ShiftOverflowTests.cs
@@ -1,0 +1,17 @@
+using Pragmastat;
+
+namespace Pragmastat.Tests;
+
+// Regression: shift search bounds x[0]-y[n-1] and x[m-1]-y[0] can overflow to
+// +-Infinity on extreme finite input, turning the midpoint into NaN and returning
+// +-Infinity instead of the true finite shift.
+public class ShiftOverflowTests
+{
+  [Fact]
+  public void ShiftDoesNotOverflowOnExtremeFiniteInput()
+  {
+    const double max = double.MaxValue;
+    Assert.Equal(0.0, Toolkit.Shift(new[] { -max, max }, new[] { -max, max }, assumeSorted: true));
+    Assert.Equal(max, Toolkit.Shift(new[] { 0.0, max }, new[] { -max, 0.0 }, assumeSorted: true));
+  }
+}

--- a/cs/Pragmastat/Algorithms/CenterImpl.cs
+++ b/cs/Pragmastat/Algorithms/CenterImpl.cs
@@ -1,4 +1,5 @@
 using Pragmastat.Internal;
+using Pragmastat.Randomization;
 
 namespace Pragmastat.Algorithms;
 
@@ -21,17 +22,17 @@ internal static class CenterImpl
   /// (1984) DOI: 10.1145/1271.319414
   /// </remarks>
   /// <param name="values">Sample values; sorted only when assumeSorted is true</param>
-  /// <param name="random">Random number generator</param>
   /// <param name="assumeSorted">If values are sorted</param>
   /// <returns>Exact center value (Hodges-Lehmann estimator)</returns>
-  public static double Estimate(IReadOnlyList<double> values, Random? random = null, bool assumeSorted = false)
+  public static double Estimate(IReadOnlyList<double> values, bool assumeSorted = false)
   {
     int n = values.Count;
     if (n == 1) return values[0];
     // Overflow-safe, order-symmetric midpoint: 0.5*a + 0.5*b (halve before summing;
     // never overflows; operand order is irrelevant).
     if (n == 2) return Midpoint(values[0], values[1]);
-    random ??= new Random();
+    // Deterministic RNG seeded from the input (FNV-1a), matching the other languages.
+    var rng = new Rng((long)Fnv1a.HashDoubles(values));
     if (!assumeSorted)
       values = values.CopyToArrayAndSort();
 
@@ -209,9 +210,7 @@ internal static class CenterImpl
       if (activeSetSize > 2)
       {
         // Use randomized row median strategy for efficiency
-        // Handle large activeSetSize by using double precision for random selection
-        double randomFraction = random.NextDouble();
-        long targetIndex = (long)(randomFraction * activeSetSize);
+        long targetIndex = rng.UniformInt64(0, activeSetSize);
         int selectedRow = 0;
 
         // Find which row contains the target index

--- a/cs/Pragmastat/Algorithms/ShiftImpl.cs
+++ b/cs/Pragmastat/Algorithms/ShiftImpl.cs
@@ -89,6 +89,14 @@ internal static class ShiftImpl
     if (double.IsNaN(searchMin) || double.IsNaN(searchMax))
       throw new InvalidOperationException("NaN in input values.");
 
+    // Extreme finite input can overflow the bounds to +-Infinity, making the
+    // midpoint NaN; every finite pairwise diff lies within [-MaxValue, MaxValue].
+    // (Ternary rather than Math.CopySign, which is absent on netstandard2.0.)
+    if (double.IsInfinity(searchMin))
+      searchMin = searchMin > 0 ? double.MaxValue : -double.MaxValue;
+    if (double.IsInfinity(searchMax))
+      searchMax = searchMax > 0 ? double.MaxValue : -double.MaxValue;
+
     const int maxIterations = 128; // Sufficient for double precision convergence
     double prevMin = double.NegativeInfinity;
     double prevMax = double.PositiveInfinity;

--- a/cs/Pragmastat/Algorithms/SpreadImpl.cs
+++ b/cs/Pragmastat/Algorithms/SpreadImpl.cs
@@ -1,3 +1,5 @@
+using Pragmastat.Randomization;
+
 namespace Pragmastat.Algorithms;
 
 internal static class SpreadImpl
@@ -14,12 +16,13 @@ internal static class SpreadImpl
   /// <summary>
   /// Shamos "Spread".  Expected O(n log n) time, O(n) extra space. Exact.
   /// </summary>
-  public static double Estimate(IReadOnlyList<double> values, Random? random = null, bool assumeSorted = false)
+  public static double Estimate(IReadOnlyList<double> values, bool assumeSorted = false)
   {
     int n = values.Count;
     if (n <= 1) return 0;
     if (n == 2) return Abs(values[1] - values[0]);
-    random ??= new Random();
+    // Deterministic RNG seeded from the input (FNV-1a), matching the other languages.
+    var rng = new Rng((long)Fnv1a.HashDoubles(values));
 
     // Prepare a sorted working copy.
     double[] a = assumeSorted ? CopyTrusted(values) : CopyAndSort(values);
@@ -227,7 +230,7 @@ internal static class SpreadImpl
       }
       else
       {
-        long t = NextIndex(random, activeSize); // 0..activeSize-1
+        long t = rng.UniformInt64(0, activeSize); // 0..activeSize-1
         long acc = 0;
         int row = 0;
         for (; row < n - 1; row++)
@@ -279,23 +282,5 @@ internal static class SpreadImpl
     }
 
     return a;
-  }
-
-  private static long NextIndex(Random rng, long limitExclusive)
-  {
-    // Uniform 0..limitExclusive-1 even for large ranges.
-    // Use rejection sampling for correctness.
-    ulong uLimit = (ulong)limitExclusive;
-    if (uLimit <= int.MaxValue)
-    {
-      return rng.Next((int)uLimit);
-    }
-
-    while (true)
-    {
-      ulong u = ((ulong)(uint)rng.Next() << 32) | (uint)rng.Next();
-      ulong r = u % uLimit;
-      if (u - r <= ulong.MaxValue - (ulong.MaxValue % uLimit)) return (long)r;
-    }
   }
 }

--- a/cs/Pragmastat/ComparisonVerdict.cs
+++ b/cs/Pragmastat/ComparisonVerdict.cs
@@ -1,3 +1,21 @@
+using System;
+
 namespace Pragmastat;
 
 public enum ComparisonVerdict { Inconclusive, Less, Greater }
+
+/// <summary>Extension helpers for <see cref="ComparisonVerdict"/>.</summary>
+public static class ComparisonVerdictExtensions
+{
+  /// <summary>
+  /// Canonical lowercase identifier ("less"/"greater"/"inconclusive"),
+  /// matching the string every other language port emits.
+  /// </summary>
+  public static string ToId(this ComparisonVerdict verdict) => verdict switch
+  {
+    ComparisonVerdict.Less => "less",
+    ComparisonVerdict.Greater => "greater",
+    ComparisonVerdict.Inconclusive => "inconclusive",
+    _ => throw new ArgumentOutOfRangeException(nameof(verdict), verdict, null)
+  };
+}

--- a/cs/Pragmastat/Randomization/Rng.cs
+++ b/cs/Pragmastat/Randomization/Rng.cs
@@ -113,6 +113,7 @@ public sealed class Rng
   /// <param name="min">Minimum value (inclusive).</param>
   /// <param name="max">Maximum value (exclusive).</param>
   /// <returns>A random long in [min, max). Returns min if min >= max.</returns>
+  /// <exception cref="OverflowException">Thrown if the range exceeds 2^52.</exception>
   public long UniformInt64(long min, long max)
   {
     return _inner.UniformInt64(min, max);

--- a/cs/Pragmastat/Randomization/Xoshiro256.cs
+++ b/cs/Pragmastat/Randomization/Xoshiro256.cs
@@ -133,13 +133,17 @@ internal sealed class Xoshiro256PlusPlus
   /// Generate a uniform long in [min, max).
   /// Returns min if min >= max.
   /// </summary>
-  /// <exception cref="OverflowException">Thrown if max - min overflows.</exception>
+  /// <exception cref="OverflowException">Thrown if the range exceeds 2^52.</exception>
   [MethodImpl(MethodImplOptions.AggressiveInlining)]
   public long UniformInt64(long min, long max)
   {
     if (min >= max)
       return min;
-    ulong range = checked((ulong)(max - min));
+    // 2^52 is the largest range all implementations (incl. double-based R) can
+    // sample exactly; well beyond any real sample.
+    ulong range = (ulong)max - (ulong)min;
+    if (range > (1UL << 52))
+      throw new OverflowException("UniformInt64: range exceeds 2^52");
     return min + (long)(NextU64() % range);
   }
 

--- a/cs/Pragmastat/Randomization/Xoshiro256.cs
+++ b/cs/Pragmastat/Randomization/Xoshiro256.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text;
 
@@ -271,6 +272,26 @@ internal static class Fnv1a
     {
       hash ^= b;
       hash *= Prime;
+    }
+    return hash;
+  }
+
+  /// <summary>
+  /// Compute FNV-1a 64-bit hash of double values by their raw IEEE-754 bits.
+  /// Used to derive a deterministic RNG seed from the input, matching the other
+  /// language implementations.
+  /// </summary>
+  public static ulong HashDoubles(IReadOnlyList<double> values)
+  {
+    ulong hash = OffsetBasis;
+    foreach (double v in values)
+    {
+      ulong bits = (ulong)BitConverter.DoubleToInt64Bits(v);
+      for (int i = 0; i < 8; i++)
+      {
+        hash ^= (bits >> (i * 8)) & 0xff;
+        hash *= Prime;
+      }
     }
     return hash;
   }

--- a/cs/README.md
+++ b/cs/README.md
@@ -21,6 +21,7 @@ Pragmastat on NuGet: https://www.nuget.org/packages/Pragmastat/
 ```cs
 using static System.Console;
 using Pragmastat.Distributions;
+using Pragmastat.Metrology;
 using Pragmastat.Randomization;
 
 namespace Pragmastat.Demo;
@@ -49,6 +50,11 @@ class Program
     WriteLine(x.RatioBounds(y));                  // [0.4066666666666668;0.5958333333333332]
     WriteLine(x.Disparity(y));                    // -1.694915254237288
     WriteLine(x.DisparityBounds(y, 1e-3, "demo")); // [-3.1025641025641026;-0.8494623655913979]
+
+    // --- Confirmatory Comparison ---
+
+    WriteLine(Toolkit.Compare1(x, [new Threshold(Metric.Center, new Measurement(50, MeasurementUnit.Number), 1e-3)])[0].Verdict.ToId()); // greater
+    WriteLine(Toolkit.Compare2(x, y, [new Threshold(Metric.Shift, new Measurement(0, MeasurementUnit.Number), 1e-3)])[0].Verdict.ToId()); // less
 
     // --- Randomization ---
 

--- a/go/README.md
+++ b/go/README.md
@@ -41,6 +41,20 @@ func mustS(val *pragmastat.Sample, err error) *pragmastat.Sample {
 	return val
 }
 
+func mustT(val *pragmastat.Threshold, err error) *pragmastat.Threshold {
+	if err != nil {
+		log.Fatal(err)
+	}
+	return val
+}
+
+func mustP(val []pragmastat.Projection, err error) []pragmastat.Projection {
+	if err != nil {
+		log.Fatal(err)
+	}
+	return val
+}
+
 func main() {
 	// --- One-Sample ---
 
@@ -74,6 +88,16 @@ func main() {
 	fmt.Println(mustB(sx.RatioBounds(sy, 1e-3)))                     // [0.4066666666666668;0.5958333333333332]
 	fmt.Println(mustM(sx.Disparity(sy)).Value)                       // -1.694915254237288
 	fmt.Println(mustB(sx.DisparityBoundsWithSeed(sy, 1e-3, "demo"))) // [-3.1025641025641026;-0.8494623655913979]
+
+	// --- Confirmatory Comparison ---
+
+	th1 := mustT(pragmastat.NewThreshold(pragmastat.MetricCenter, pragmastat.NewNumberMeasurement(50), 1e-3))
+	proj1 := mustP(pragmastat.Compare1(sx, []*pragmastat.Threshold{th1}))
+	fmt.Println(proj1[0].Verdict) // greater
+
+	th2 := mustT(pragmastat.NewThreshold(pragmastat.MetricShift, pragmastat.NewNumberMeasurement(0), 1e-3))
+	proj2 := mustP(pragmastat.Compare2(sx, sy, []*pragmastat.Threshold{th2}))
+	fmt.Println(proj2[0].Verdict) // less
 
 	// --- Randomization ---
 

--- a/go/demo/main.go
+++ b/go/demo/main.go
@@ -28,6 +28,20 @@ func mustS(val *pragmastat.Sample, err error) *pragmastat.Sample {
 	return val
 }
 
+func mustT(val *pragmastat.Threshold, err error) *pragmastat.Threshold {
+	if err != nil {
+		log.Fatal(err)
+	}
+	return val
+}
+
+func mustP(val []pragmastat.Projection, err error) []pragmastat.Projection {
+	if err != nil {
+		log.Fatal(err)
+	}
+	return val
+}
+
 func main() {
 	// --- One-Sample ---
 
@@ -61,6 +75,16 @@ func main() {
 	fmt.Println(mustB(sx.RatioBounds(sy, 1e-3)))                     // [0.4066666666666668;0.5958333333333332]
 	fmt.Println(mustM(sx.Disparity(sy)).Value)                       // -1.694915254237288
 	fmt.Println(mustB(sx.DisparityBoundsWithSeed(sy, 1e-3, "demo"))) // [-3.1025641025641026;-0.8494623655913979]
+
+	// --- Confirmatory Comparison ---
+
+	th1 := mustT(pragmastat.NewThreshold(pragmastat.MetricCenter, pragmastat.NewNumberMeasurement(50), 1e-3))
+	proj1 := mustP(pragmastat.Compare1(sx, []*pragmastat.Threshold{th1}))
+	fmt.Println(proj1[0].Verdict) // greater
+
+	th2 := mustT(pragmastat.NewThreshold(pragmastat.MetricShift, pragmastat.NewNumberMeasurement(0), 1e-3))
+	proj2 := mustP(pragmastat.Compare2(sx, sy, []*pragmastat.Threshold{th2}))
+	fmt.Println(proj2[0].Verdict) // less
 
 	// --- Randomization ---
 

--- a/go/shift_impl.go
+++ b/go/shift_impl.go
@@ -143,6 +143,17 @@ func selectKthPairwiseDiff[T Number](x, y []T, k int64) (float64, error) {
 		return 0, errors.New("NaN in input values")
 	}
 
+	// The bounds x[0]-y[n-1] and x[m-1]-y[0] can overflow to -Inf/+Inf on
+	// finite extreme input; that makes the midpoint 0.5*min+0.5*max a NaN and
+	// derails the search. Every finite pairwise diff lies within
+	// [-MaxFloat64, MaxFloat64], so clamp the bounds to that range.
+	if math.IsInf(searchMin, 0) {
+		searchMin = math.Copysign(math.MaxFloat64, searchMin)
+	}
+	if math.IsInf(searchMax, 0) {
+		searchMax = math.Copysign(math.MaxFloat64, searchMax)
+	}
+
 	const maxIterations = 128 // Sufficient for double precision convergence
 	prevMin := math.Inf(-1)
 	prevMax := math.Inf(1)

--- a/go/shift_overflow_test.go
+++ b/go/shift_overflow_test.go
@@ -1,0 +1,30 @@
+package pragmastat
+
+import (
+	"math"
+	"testing"
+)
+
+// Regression: search bounds x[0]-y[n-1] and x[m-1]-y[0] can overflow to +-Inf on
+// finite extreme input, turning the midpoint into NaN and returning +-Inf instead
+// of the true finite shift.
+func TestShift_Overflow(t *testing.T) {
+	max := math.MaxFloat64
+	tests := []struct {
+		name string
+		x, y []float64
+		want float64
+	}{
+		{"symmetric extremes", []float64{-max, max}, []float64{-max, max}, 0},
+		{"one-sided extremes", []float64{0, max}, []float64{-max, 0}, max},
+	}
+	for _, tt := range tests {
+		got, err := Shift(tt.x, tt.y, true)
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", tt.name, err)
+		}
+		if got != tt.want {
+			t.Errorf("%s: Shift = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}

--- a/go/xoshiro256.go
+++ b/go/xoshiro256.go
@@ -91,6 +91,11 @@ func (x *xoshiro256PlusPlus) uniformInt64(min, max int64) int64 {
 	}
 	// uint64 subtraction gives correct unsigned distance for all int64 pairs
 	rangeSize := uint64(max) - uint64(min)
+	// 2^52 is the largest range all implementations (incl. double-based R) can
+	// sample exactly; well beyond any real sample.
+	if rangeSize > (1 << 52) {
+		panic("uniformInt64: range exceeds 2^52")
+	}
 	return min + int64(x.nextU64()%rangeSize)
 }
 

--- a/kt/README.md
+++ b/kt/README.md
@@ -54,6 +54,11 @@ fun main() {
     println(disparity(sx, sy)) // -1.694915254237288
     println(disparityBounds(sx, sy, Probability(1e-3), "demo")) // Bounds(lower=-3.1025..., upper=-0.8494..., unit=...)
 
+    // --- Confirmatory Comparison ---
+
+    println(compare1(sx, listOf(Threshold(Metric.Center, Measurement(50.0), Probability(1e-3))))[0].verdict.toId()) // greater
+    println(compare2(sx, sy, listOf(Threshold(Metric.Shift, Measurement(0.0), Probability(1e-3))))[0].verdict.toId()) // less
+
     // --- Custom units ---
 
     val ns = MeasurementUnit("ns", "Time", "ns", "Nanosecond", 1)

--- a/kt/demo/src/main/kotlin/dev/pragmastat/demo/Main.kt
+++ b/kt/demo/src/main/kotlin/dev/pragmastat/demo/Main.kt
@@ -23,6 +23,11 @@ fun main() {
     println(disparity(sx, sy)) // -1.694915254237288
     println(disparityBounds(sx, sy, Probability(1e-3), "demo")) // Bounds(lower=-3.1025..., upper=-0.8494..., unit=...)
 
+    // --- Confirmatory Comparison ---
+
+    println(compare1(sx, listOf(Threshold(Metric.Center, Measurement(50.0), Probability(1e-3))))[0].verdict.toId()) // greater
+    println(compare2(sx, sy, listOf(Threshold(Metric.Shift, Measurement(0.0), Probability(1e-3))))[0].verdict.toId()) // less
+
     // --- Custom units ---
 
     val ns = MeasurementUnit("ns", "Time", "ns", "Nanosecond", 1)

--- a/kt/src/main/kotlin/dev/pragmastat/Compare.kt
+++ b/kt/src/main/kotlin/dev/pragmastat/Compare.kt
@@ -18,6 +18,10 @@ enum class ComparisonVerdict {
     Less,
     Greater,
     Inconclusive,
+    ;
+
+    /** Canonical lowercase identifier ("less"/"greater"/"inconclusive"), matching the other ports. */
+    fun toId(): String = name.lowercase()
 }
 
 /**

--- a/kt/src/main/kotlin/dev/pragmastat/PairwiseMargin.kt
+++ b/kt/src/main/kotlin/dev/pragmastat/PairwiseMargin.kt
@@ -248,13 +248,13 @@ private fun binomialCoefficient(
     if (kk == 0 || kk == n) return 1.0
 
     kk = minOf(kk, n - kk) // Take advantage of symmetry
-    var result = 1.0
+    var result = 1L // exact integer arithmetic: each partial product is divisible
 
     for (i in 0 until kk) {
         result = result * (n - i) / (i + 1)
     }
 
-    return result
+    return result.toDouble()
 }
 
 /**

--- a/kt/src/main/kotlin/dev/pragmastat/ShiftImpl.kt
+++ b/kt/src/main/kotlin/dev/pragmastat/ShiftImpl.kt
@@ -91,6 +91,15 @@ internal fun selectKthPairwiseDiff(
         throw IllegalStateException("NaN in input values")
     }
 
+    // Extreme finite input can overflow the bounds to -/+Infinity, making the
+    // midpoint a NaN; every finite pairwise diff lies within [-MAX_VALUE, MAX_VALUE].
+    if (searchMin.isInfinite()) {
+        searchMin = Math.copySign(Double.MAX_VALUE, searchMin)
+    }
+    if (searchMax.isInfinite()) {
+        searchMax = Math.copySign(Double.MAX_VALUE, searchMax)
+    }
+
     val maxIterations = 128 // Sufficient for double precision convergence
     var prevMin = Double.NEGATIVE_INFINITY
     var prevMax = Double.POSITIVE_INFINITY

--- a/kt/src/main/kotlin/dev/pragmastat/SpreadImpl.kt
+++ b/kt/src/main/kotlin/dev/pragmastat/SpreadImpl.kt
@@ -88,13 +88,13 @@ internal fun spreadImpl(
         if (countBelow == prevCountBelow) {
             var minActive = Double.POSITIVE_INFINITY
             var maxActive = Double.NEGATIVE_INFINITY
-            var active = 0
+            var active = 0L
 
             for (i in 0 until n - 1) {
                 if (L[i] > R[i]) continue
                 minActive = minOf(minActive, a[L[i]] - a[i])
                 maxActive = maxOf(maxActive, a[R[i]] - a[i])
-                active += R[i] - L[i] + 1
+                active += (R[i] - L[i] + 1).toLong()
             }
 
             if (active <= 0) {

--- a/kt/src/main/kotlin/dev/pragmastat/Xoshiro256.kt
+++ b/kt/src/main/kotlin/dev/pragmastat/Xoshiro256.kt
@@ -97,14 +97,17 @@ internal class Xoshiro256PlusPlus(
 
     /**
      * Generate a uniform Long in [min, max).
-     * @throws ArithmeticException if max - min overflows.
+     * @throws ArithmeticException if the range exceeds 2^52.
      */
     fun uniformLong(
         min: Long,
         max: Long,
     ): Long {
         if (min >= max) return min
-        val range = Math.subtractExact(max, min).toULong()
+        // 2^52 is the largest range all implementations (incl. double-based R)
+        // can sample exactly; well beyond any real sample.
+        val range = max.toULong() - min.toULong()
+        if (range > (1UL shl 52)) throw ArithmeticException("uniformLong: range exceeds 2^52")
         return min + (nextU64() % range).toLong()
     }
 

--- a/kt/src/test/kotlin/dev/pragmastat/PairwiseMarginConsistencyTest.kt
+++ b/kt/src/test/kotlin/dev/pragmastat/PairwiseMarginConsistencyTest.kt
@@ -1,0 +1,14 @@
+package dev.pragmastat
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class PairwiseMarginConsistencyTest {
+    // Regression: the exact binomial coefficient must use integer arithmetic. Float
+    // accumulation overflowed 2^53 in the partial products for C(56,27), giving a
+    // margin of 784 instead of the correct 782 at misrate 1.0.
+    @Test
+    fun `pairwise margin matches exact-integer binomial`() {
+        assertEquals(782, pairwiseMargin(29, 27, 1.0))
+    }
+}

--- a/kt/src/test/kotlin/dev/pragmastat/ShiftOverflowTest.kt
+++ b/kt/src/test/kotlin/dev/pragmastat/ShiftOverflowTest.kt
@@ -1,0 +1,16 @@
+package dev.pragmastat
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class ShiftOverflowTest {
+    // Regression: shift search bounds x[0]-y[n-1] and x[m-1]-y[0] can overflow to
+    // -/+Infinity on extreme finite input, turning the midpoint into NaN and
+    // returning +-Infinity instead of the true finite shift.
+    @Test
+    fun `shift does not overflow search bounds on extreme finite input`() {
+        val max = Double.MAX_VALUE
+        assertEquals(0.0, shift(listOf(-max, max), listOf(-max, max), assumeSorted = true))
+        assertEquals(max, shift(listOf(0.0, max), listOf(-max, 0.0), assumeSorted = true))
+    }
+}

--- a/kt/src/test/kotlin/dev/pragmastat/SpreadOverflowTest.kt
+++ b/kt/src/test/kotlin/dev/pragmastat/SpreadOverflowTest.kt
@@ -1,0 +1,16 @@
+package dev.pragmastat
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class SpreadOverflowTest {
+    // Regression: the internal `active` pair counter must be Long. For n >= 65537 the
+    // number of pairs exceeds Int.MAX, and an Int counter wrapped negative, tripping the
+    // `active <= 0` guard and returning -Infinity instead of 0 for a constant vector.
+    @Test
+    fun `spreadImpl does not overflow the active counter on large constant input`() {
+        val n = 65537
+        val x = List(n) { 42.0 }
+        assertEquals(0.0, spreadImpl(x, assumeSorted = true))
+    }
+}

--- a/py/README.md
+++ b/py/README.md
@@ -14,10 +14,14 @@ Pragmastat on PyPI: https://pypi.org/project/pragmastat/
 
 ```python
 from pragmastat import (
+    Metric,
     Rng,
     Sample,
+    Threshold,
     center,
     center_bounds,
+    compare1,
+    compare2,
     disparity,
     disparity_bounds,
     ratio,
@@ -61,6 +65,17 @@ def main():
     print(
         f"Bounds(lower={bounds.lower}, upper={bounds.upper})"
     )  # Bounds(lower=-3.1025641025641026, upper=-0.8494623655913979)
+
+    # --- Confirmatory Comparison ---
+
+    x = Sample(list(range(1, 201)))
+    projection = compare1(x, [Threshold(Metric.CENTER, 50.0, 1e-3)])[0]
+    print(projection.verdict.value)  # greater
+
+    x = Sample(list(range(1, 201)))
+    y = Sample(list(range(101, 301)))
+    projection = compare2(x, y, [Threshold(Metric.SHIFT, 0.0, 1e-3)])[0]
+    print(projection.verdict.value)  # less
 
     # --- Randomization ---
 

--- a/py/examples/demo.py
+++ b/py/examples/demo.py
@@ -1,8 +1,12 @@
 from pragmastat import (
+    Metric,
     Rng,
     Sample,
+    Threshold,
     center,
     center_bounds,
+    compare1,
+    compare2,
     disparity,
     disparity_bounds,
     ratio,
@@ -46,6 +50,17 @@ def main():
     print(
         f"Bounds(lower={bounds.lower}, upper={bounds.upper})"
     )  # Bounds(lower=-3.1025641025641026, upper=-0.8494623655913979)
+
+    # --- Confirmatory Comparison ---
+
+    x = Sample(list(range(1, 201)))
+    projection = compare1(x, [Threshold(Metric.CENTER, 50.0, 1e-3)])[0]
+    print(projection.verdict.value)  # greater
+
+    x = Sample(list(range(1, 201)))
+    y = Sample(list(range(101, 301)))
+    projection = compare2(x, y, [Threshold(Metric.SHIFT, 0.0, 1e-3)])[0]
+    print(projection.verdict.value)  # less
 
     # --- Randomization ---
 

--- a/py/pragmastat/pairwise_margin.py
+++ b/py/pragmastat/pairwise_margin.py
@@ -209,12 +209,12 @@ def _binomial_coefficient(n: int, k: int) -> float:
         return 1.0
 
     k = min(k, n - k)  # Take advantage of symmetry
-    result = 1.0
+    result = 1  # exact integer arithmetic: each partial product is divisible
 
     for i in range(k):
-        result = result * (n - i) / (i + 1)
+        result = result * (n - i) // (i + 1)
 
-    return result
+    return float(result)
 
 
 def _binomial_coefficient_float(n: int, k: int) -> float:

--- a/py/pragmastat/shift_impl.py
+++ b/py/pragmastat/shift_impl.py
@@ -99,6 +99,14 @@ def _select_kth_pairwise_diff(x: list[float], y: list[float], k: int) -> float:
     if np.isnan(search_min) or np.isnan(search_max):
         raise ValueError("NaN in input values")
 
+    # Extreme finite input can overflow the bounds to +-inf, making the midpoint
+    # NaN; every finite pairwise diff lies within [-DBL_MAX, DBL_MAX].
+    dbl_max = np.finfo(np.float64).max
+    if np.isinf(search_min):
+        search_min = np.copysign(dbl_max, search_min)
+    if np.isinf(search_max):
+        search_max = np.copysign(dbl_max, search_max)
+
     max_iterations = 128  # Sufficient for double precision convergence
     prev_min = float("-inf")
     prev_max = float("inf")

--- a/py/pragmastat/xoshiro256.py
+++ b/py/pragmastat/xoshiro256.py
@@ -84,13 +84,15 @@ class Xoshiro256PlusPlus:
         """Generate a uniform integer in [min, max).
 
         Raises:
-            OverflowError: If max_val - min_val exceeds u64 range.
+            OverflowError: If max_val - min_val exceeds 2**52.
         """
         if min_val >= max_val:
             return min_val
         range_size = max_val - min_val
-        if range_size > 0xFFFFFFFFFFFFFFFF:
-            raise OverflowError("uniform_int: range overflow (max - min exceeds u64)")
+        # 2^52 is the largest range all implementations (incl. double-based R)
+        # can sample exactly; well beyond any real sample.
+        if range_size > (1 << 52):
+            raise OverflowError("uniform_int: range exceeds 2^52")
         return min_val + (self.next_u64() % range_size)
 
     # ========================================================================

--- a/py/src/shift_impl_c.c
+++ b/py/src/shift_impl_c.c
@@ -2,6 +2,7 @@
 #include <Python.h>
 #include <numpy/arrayobject.h>
 #include <math.h>
+#include <float.h>
 #include <stdlib.h>
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
@@ -91,6 +92,15 @@ static double select_kth_pairwise_diff(
     if (isnan(search_min) || isnan(search_max)) {
         PyErr_SetString(PyExc_ValueError, "NaN in input values");
         return NAN;
+    }
+
+    /* Extreme finite input can overflow the bounds to -/+inf, making the
+       midpoint a NaN; every finite pairwise diff lies within [-DBL_MAX, DBL_MAX]. */
+    if (isinf(search_min)) {
+        search_min = copysign(DBL_MAX, search_min);
+    }
+    if (isinf(search_max)) {
+        search_max = copysign(DBL_MAX, search_max);
     }
 
     const int max_iterations = 128;

--- a/py/tests/test_pairwise_margin_consistency.py
+++ b/py/tests/test_pairwise_margin_consistency.py
@@ -1,0 +1,11 @@
+"""Regression: the exact binomial coefficient must use integer arithmetic.
+
+Float accumulation overflowed 2^53 in the partial products for C(56,27), giving
+a margin of 784 instead of the correct 782 (go/cs/rs/r) at misrate 1.0.
+"""
+
+from pragmastat.pairwise_margin import pairwise_margin
+
+
+def test_pairwise_margin_exact_integer_binomial():
+    assert pairwise_margin(29, 27, 1.0) == 782

--- a/py/tests/test_shift_overflow.py
+++ b/py/tests/test_shift_overflow.py
@@ -1,0 +1,17 @@
+"""Regression: shift search bounds can overflow to +-inf on extreme finite input,
+turning the midpoint into NaN and returning +-inf instead of the true finite shift.
+"""
+
+import sys
+
+from pragmastat import shift
+
+MAX = sys.float_info.max
+
+
+def test_shift_symmetric_extremes():
+    assert shift([-MAX, MAX], [-MAX, MAX], assume_sorted=True) == 0.0
+
+
+def test_shift_one_sided_extremes():
+    assert shift([0.0, MAX], [-MAX, 0.0], assume_sorted=True) == MAX

--- a/r/pragmastat/R/binomial.R
+++ b/r/pragmastat/R/binomial.R
@@ -1,0 +1,8 @@
+# Exact binomial coefficient C(n, k) via native 64-bit integer arithmetic.
+# R's built-in choose() is floating point and inexact for the exact
+# distribution branch (n + m < 62), so it disagreed with the go/rust/... ports.
+# Delegating to src/binomial.c keeps all seven implementations bit-for-bit
+# identical. See min_achievable_misrate_two_sample and pairwise_margin.
+exact_binomial <- function(n, k) {
+  .Call("binomial_coefficient_c", as.integer(n), as.integer(k), PACKAGE = "pragmastat")
+}

--- a/r/pragmastat/R/min_misrate.R
+++ b/r/pragmastat/R/min_misrate.R
@@ -20,5 +20,11 @@ min_achievable_misrate_one_sample <- function(n) {
 min_achievable_misrate_two_sample <- function(n, m) {
   if (n <= 0) stop(assumption_error(ASSUMPTION_IDS$DOMAIN, SUBJECTS$X))
   if (m <= 0) stop(assumption_error(ASSUMPTION_IDS$DOMAIN, SUBJECTS$Y))
-  2 / choose(n + m, n)
+  # Exact integer binomial below n + m = 62 (matches the other six ports);
+  # logarithmic approximation above, where the value exceeds 64-bit range.
+  if (n + m < 62) {
+    2 / exact_binomial(n + m, n)
+  } else {
+    2 / exp(lchoose(n + m, n))
+  }
 }

--- a/r/pragmastat/R/pairwise_margin.R
+++ b/r/pragmastat/R/pairwise_margin.R
@@ -44,10 +44,10 @@ pairwise_margin_approx <- function(n, m, misrate) {
 # pairwise_margin_exact_raw implements the inversed Loeffler (1982) algorithm
 # Reference: "Über eine Partition der nat. Zahlen und ihre Anwendung beim U-Test"
 pairwise_margin_exact_raw <- function(n, m, p) {
-  # Use R's built-in choose() function for binomial coefficient
-  # For large values, use logarithmic calculation
+  # Exact integer binomial for small samples (matches the other six ports
+  # bit-for-bit); logarithmic approximation for large values.
   if (n + m < 62) {
-    total <- choose(n + m, m)
+    total <- exact_binomial(n + m, m)
   } else {
     total <- exp(lchoose(n + m, m))
   }

--- a/r/pragmastat/R/xoshiro256.R
+++ b/r/pragmastat/R/xoshiro256.R
@@ -198,37 +198,39 @@ u64_mul <- function(a, b) {
   u64(hi, lo)
 }
 
-# Modulo (for uniform_int) - a is u64, b is a small positive numeric.
-# Exact for b < 2^32 by decomposing hi_mod into 16-bit chunks
-# to keep all intermediate products within the 53-bit mantissa.
+# (a * b) mod m for a, b in [0, m) and m in [1, 2^52]. Russian-peasant doubling
+# with conditional subtracts keeps every intermediate below 2^53, so all the
+# arithmetic is exact in double precision.
+u64_mulmod <- function(a, b, m) {
+  result <- 0
+  while (b > 0) {
+    if (b %% 2 == 1) {
+      result <- result + a
+      if (result >= m) result <- result - m
+    }
+    a <- a + a
+    if (a >= m) a <- a - m
+    b <- floor(b / 2)
+  }
+  result
+}
+
+# Modulo (for uniform_int): a is a u64, b a positive numeric <= 2^52.
+# a mod b = ((hi mod b) * (2^32 mod b) + (lo mod b)) mod b, evaluated with mulmod
+# so it stays exact for every modulus that fits the 53-bit mantissa (the caller
+# rejects larger ranges).
 u64_mod <- function(a, b_numeric) {
-  if (b_numeric <= 0) {
+  if (b_numeric <= 1) {
     return(0)
   }
-  if (b_numeric == 1) {
-    return(0)
+  hi_mod <- a$hi %% b_numeric
+  lo_mod <- a$lo %% b_numeric
+  pow32_mod <- 4294967296 %% b_numeric
+  result <- u64_mulmod(hi_mod, pow32_mod, b_numeric) + lo_mod
+  if (result >= b_numeric) {
+    result <- result - b_numeric
   }
-
-  # (hi * 2^32 + lo) mod b = ((hi mod b) * (2^32 mod b) + (lo mod b)) mod b
-  # Split hi_mod into 16-bit chunks so each product stays within 2^48 < 2^53
-
-  if (b_numeric < 4294967296) {
-    hi_mod <- a$hi %% b_numeric
-    lo_mod <- a$lo %% b_numeric
-    pow32_mod <- 4294967296 %% b_numeric
-
-    hi_mod_lo <- hi_mod %% 65536
-    hi_mod_hi <- floor(hi_mod / 65536)
-    t1 <- (hi_mod_hi * pow32_mod) %% b_numeric
-    t2 <- (t1 * 65536) %% b_numeric
-    t3 <- (hi_mod_lo * pow32_mod) %% b_numeric
-    result <- (t2 + t3 + lo_mod) %% b_numeric
-    return(result)
-  }
-
-  # For larger moduli, use direct conversion (may lose some precision for very large a)
-  a_numeric <- u64_to_numeric(a)
-  a_numeric %% b_numeric
+  result
 }
 
 # Module-level constants for splitmix64 and FNV-1a (avoid re-creation per call)
@@ -317,9 +319,10 @@ xoshiro256_uniform_int <- function(xo, min_val, max_val) {
     return(min_val)
   }
   range_size <- as.numeric(max_val - min_val)
-  # Validate range fits in i64 (for cross-language consistency)
-  if (range_size > 9223372036854775807) {
-    stop("uniform_int: range overflow (max - min exceeds i64)")
+  # Ranges above 2^52 cannot be sampled exactly with double-based arithmetic;
+  # reject them for cross-language consistency (well beyond any real sample).
+  if (range_size > 4503599627370496) {
+    stop("uniform_int: range exceeds 2^52")
   }
   u64_val <- xoshiro256_next_u64(xo)
   # Return as numeric to avoid as.integer() truncation for values > 2^31-1

--- a/r/pragmastat/README.md
+++ b/r/pragmastat/README.md
@@ -42,6 +42,16 @@ print(disparity(x, y)) # -1.694915
 bounds <- disparity_bounds(x, y, 1e-3, seed = "demo")
 print(paste("[", bounds$lower, ", ", bounds$upper, "]", sep = "")) # [-3.1025641025641, -0.849462365591398]
 
+# --- Confirmatory Comparison ---
+
+sx <- Sample$new(x)
+t1 <- list(list(metric = METRIC_CENTER, value = Measurement$new(50), misrate = 1e-3))
+print(compare1(sx, t1)[[1]]$verdict) # "greater"
+
+sy <- Sample$new(y)
+t2 <- list(list(metric = METRIC_SHIFT, value = Measurement$new(0), misrate = 1e-3))
+print(compare2(sx, sy, t2)[[1]]$verdict) # "less"
+
 # --- Sample-based interface ---
 
 sx <- Sample$new(1:200)

--- a/r/pragmastat/inst/examples/demo.R
+++ b/r/pragmastat/inst/examples/demo.R
@@ -26,6 +26,16 @@ print(disparity(x, y)) # -1.694915
 bounds <- disparity_bounds(x, y, 1e-3, seed = "demo")
 print(paste("[", bounds$lower, ", ", bounds$upper, "]", sep = "")) # [-3.1025641025641, -0.849462365591398]
 
+# --- Confirmatory Comparison ---
+
+sx <- Sample$new(x)
+t1 <- list(list(metric = METRIC_CENTER, value = Measurement$new(50), misrate = 1e-3))
+print(compare1(sx, t1)[[1]]$verdict) # "greater"
+
+sy <- Sample$new(y)
+t2 <- list(list(metric = METRIC_SHIFT, value = Measurement$new(0), misrate = 1e-3))
+print(compare2(sx, sy, t2)[[1]]$verdict) # "less"
+
 # --- Sample-based interface ---
 
 sx <- Sample$new(1:200)

--- a/r/pragmastat/src/binomial.c
+++ b/r/pragmastat/src/binomial.c
@@ -1,0 +1,25 @@
+#include <R.h>
+#include <Rinternals.h>
+
+/*
+ * Exact binomial coefficient C(n, k) via 64-bit integer arithmetic,
+ * mirroring the go (int64) and rust (u128) ports. R's built-in choose()
+ * runs in floating point and is provably inexact even below 2^53 (e.g.
+ * choose(56, 27) yields ...078 instead of the exact ...080), which made
+ * R's pairwise margin and min-misrate disagree with the other six ports.
+ *
+ * Used only for the exact-distribution branch (n < 62). There the running
+ * product stays below 2^63, so unsigned 64-bit arithmetic is exact; the
+ * final cast to double matches float64(int64) in go and (u128 as f64) in rust.
+ */
+SEXP binomial_coefficient_c(SEXP n_sexp, SEXP k_sexp) {
+    int n = asInteger(n_sexp);
+    int k = asInteger(k_sexp);
+    if (k < 0 || k > n) return ScalarReal(0.0);
+    if (k > n - k) k = n - k;
+    unsigned long long result = 1ULL;
+    for (int i = 0; i < k; i++) {
+        result = result * (unsigned long long)(n - i) / (unsigned long long)(i + 1);
+    }
+    return ScalarReal((double)result);
+}

--- a/r/pragmastat/src/init.c
+++ b/r/pragmastat/src/init.c
@@ -6,12 +6,14 @@
 SEXP center_impl_c(SEXP values_sexp, SEXP assume_sorted_sexp);
 SEXP spread_impl_c(SEXP values_sexp, SEXP assume_sorted_sexp);
 SEXP shift_impl_c(SEXP x_sexp, SEXP y_sexp, SEXP p_sexp, SEXP assume_sorted_sexp);
+SEXP binomial_coefficient_c(SEXP n_sexp, SEXP k_sexp);
 
 // Registration table
 static const R_CallMethodDef CallEntries[] = {
     {"center_impl_c", (DL_FUNC) &center_impl_c, 2},
     {"spread_impl_c", (DL_FUNC) &spread_impl_c, 2},
     {"shift_impl_c", (DL_FUNC) &shift_impl_c, 4},
+    {"binomial_coefficient_c", (DL_FUNC) &binomial_coefficient_c, 2},
     {NULL, NULL, 0}
 };
 

--- a/r/pragmastat/src/shift_impl.c
+++ b/r/pragmastat/src/shift_impl.c
@@ -1,6 +1,7 @@
 #include <R.h>
 #include <Rinternals.h>
 #include <math.h>
+#include <float.h>
 #include <stdlib.h>
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
@@ -85,6 +86,15 @@ static double select_kth_pairwise_diff(
 
     if (ISNAN(search_min) || ISNAN(search_max)) {
         error("NaN in input values");
+    }
+
+    /* Extreme finite input can overflow the bounds to -/+inf, making the
+       midpoint a NaN; every finite pairwise diff lies within [-DBL_MAX, DBL_MAX]. */
+    if (isinf(search_min)) {
+        search_min = copysign(DBL_MAX, search_min);
+    }
+    if (isinf(search_max)) {
+        search_max = copysign(DBL_MAX, search_max);
     }
 
     const int max_iterations = 128;

--- a/r/pragmastat/tests/testthat/test-pairwise-margin.R
+++ b/r/pragmastat/tests/testthat/test-pairwise-margin.R
@@ -35,3 +35,12 @@ test_that("pairwise_margin satisfies reference tests", {
     )
   }
 })
+
+test_that("pairwise_margin uses exact integer binomial (cross-language parity)", {
+  # R's built-in choose() is inexact even below 2^53: choose(56, 27) returns
+  # 7384942649010078, but the exact value is 7384942649010080. exact_binomial
+  # mirrors the go (int64) and rust (u128) ports bit-for-bit.
+  expect_equal(exact_binomial(56, 27), 7384942649010080)
+  # The pairwise margin all seven ports agree on for this input is 782.
+  expect_equal(pairwise_margin(29, 27, 1.0), 782)
+})

--- a/r/pragmastat/tests/testthat/test-shift-overflow.R
+++ b/r/pragmastat/tests/testthat/test-shift-overflow.R
@@ -1,0 +1,8 @@
+# Regression: shift search bounds x[1]-y[n] and x[m]-y[1] can overflow to
+# -/+Inf on extreme finite input, turning the midpoint into NaN and returning
+# +-Inf instead of the true finite shift.
+test_that("shift does not overflow search bounds on extreme finite input", {
+  max_val <- .Machine$double.xmax
+  expect_equal(shift(c(-max_val, max_val), c(-max_val, max_val), assume_sorted = TRUE), 0)
+  expect_equal(shift(c(0, max_val), c(-max_val, 0), assume_sorted = TRUE), max_val)
+})

--- a/r/pragmastat/tests/testthat/test-uniform-int-overflow.R
+++ b/r/pragmastat/tests/testthat/test-uniform-int-overflow.R
@@ -1,0 +1,16 @@
+# Regression: u64_mod lost precision for moduli >= 2^32 (it fell back to a
+# lossy double conversion). It is now exact up to 2^52 via mulmod. Oracle values
+# come from Python's exact big-integer arithmetic on 0x123456789abcdef0.
+test_that("u64_mod is exact for moduli at and above 2^32", {
+  a <- u64_from_hex("123456789abcdef0")
+  expect_equal(u64_mod(a, 2^40), 517992144624)
+  expect_equal(u64_mod(a, 2^45), 24707247955696)
+  expect_equal(u64_mod(a, 2^30), 448585456)
+})
+
+# Contract: ranges above 2^52 cannot be sampled exactly with double-based
+# arithmetic and are rejected, consistently with the other languages.
+test_that("uniform_int rejects ranges above 2^52", {
+  rng <- Rng$new(1)
+  expect_error(rng$uniform_int(0, 2^53), "2\\^52")
+})

--- a/rs/pragmastat/README.md
+++ b/rs/pragmastat/README.md
@@ -50,6 +50,14 @@ fn main() {
     let bounds = disparity_bounds_with_seed(&x, &y, 1e-3, "demo").unwrap();
     println!("{{lower: {}, upper: {}}}", bounds.lower, bounds.upper); // {lower: -3.1025641025641026, upper: -0.8494623655913979}
 
+    // --- Confirmatory Comparison ---
+
+    let th = Threshold::new(Metric::Center, Measurement::number(50.0), 1e-3).unwrap();
+    println!("{}", compare1(&x, &[th]).unwrap()[0].verdict().as_str()); // greater
+
+    let th = Threshold::new(Metric::Shift, Measurement::number(0.0), 1e-3).unwrap();
+    println!("{}", compare2(&x, &y, &[th]).unwrap()[0].verdict().as_str()); // less
+
     // --- Randomization ---
 
     let mut rng = Rng::from_string("demo-uniform");

--- a/rs/pragmastat/examples/demo.rs
+++ b/rs/pragmastat/examples/demo.rs
@@ -28,6 +28,14 @@ fn main() {
     let bounds = disparity_bounds_with_seed(&x, &y, 1e-3, "demo").unwrap();
     println!("{{lower: {}, upper: {}}}", bounds.lower, bounds.upper); // {lower: -3.1025641025641026, upper: -0.8494623655913979}
 
+    // --- Confirmatory Comparison ---
+
+    let th = Threshold::new(Metric::Center, Measurement::number(50.0), 1e-3).unwrap();
+    println!("{}", compare1(&x, &[th]).unwrap()[0].verdict().as_str()); // greater
+
+    let th = Threshold::new(Metric::Shift, Measurement::number(0.0), 1e-3).unwrap();
+    println!("{}", compare2(&x, &y, &[th]).unwrap()[0].verdict().as_str()); // less
+
     // --- Randomization ---
 
     let mut rng = Rng::from_string("demo-uniform");

--- a/rs/pragmastat/src/shift_impl.rs
+++ b/rs/pragmastat/src/shift_impl.rs
@@ -124,6 +124,15 @@ pub(crate) fn select_kth_pairwise_diff(x: &[f64], y: &[f64], k: i64) -> Result<f
         return Err("NaN in input values");
     }
 
+    // Extreme finite input can overflow the bounds to -/+infinity, making the
+    // midpoint a NaN; every finite pairwise diff lies within [-f64::MAX, f64::MAX].
+    if search_min.is_infinite() {
+        search_min = f64::MAX.copysign(search_min);
+    }
+    if search_max.is_infinite() {
+        search_max = f64::MAX.copysign(search_max);
+    }
+
     const MAX_ITERATIONS: usize = 128; // Sufficient for double precision
     let mut prev_min = f64::NEG_INFINITY;
     let mut prev_max = f64::INFINITY;

--- a/rs/pragmastat/src/xoshiro256.rs
+++ b/rs/pragmastat/src/xoshiro256.rs
@@ -80,15 +80,16 @@ impl Xoshiro256PlusPlus {
     /// Generate a uniform i64 in [min, max)
     ///
     /// # Panics
-    /// Panics if the range `max - min` overflows i64.
+    /// Panics if the range exceeds 2^52.
     #[inline]
     pub fn uniform_i64(&mut self, min: i64, max: i64) -> i64 {
         if min >= max {
             return min;
         }
-        let range =
-            max.checked_sub(min)
-                .expect("uniform_i64: range overflow (max - min exceeds i64)") as u64;
+        // 2^52 is the largest range all implementations (incl. double-based R)
+        // can sample exactly; well beyond any real sample.
+        let range = (max as u64).wrapping_sub(min as u64);
+        assert!(range <= (1u64 << 52), "uniform_i64: range exceeds 2^52");
         min + (self.next_u64() % range) as i64
     }
 

--- a/rs/pragmastat/tests/shift_overflow_tests.rs
+++ b/rs/pragmastat/tests/shift_overflow_tests.rs
@@ -1,0 +1,17 @@
+//! Regression: shift search bounds x[0]-y[n-1] and x[m-1]-y[0] can overflow to
+//! -/+inf on extreme finite input, turning the midpoint into NaN and returning
+//! +-inf instead of the true finite shift.
+
+use pragmastat::estimators::raw;
+
+#[test]
+fn shift_symmetric_extremes() {
+    let max = f64::MAX;
+    assert_eq!(raw::shift(&[-max, max], &[-max, max], true).unwrap(), 0.0);
+}
+
+#[test]
+fn shift_one_sided_extremes() {
+    let max = f64::MAX;
+    assert_eq!(raw::shift(&[0.0, max], &[-max, 0.0], true).unwrap(), max);
+}

--- a/ts/README.md
+++ b/ts/README.md
@@ -31,6 +31,11 @@ import {
   Power,
   Uniform,
   Sample,
+  Measurement,
+  Metric,
+  Threshold,
+  compare1,
+  compare2,
 } from 'pragmastat';
 
 function main(): void {
@@ -54,6 +59,11 @@ function main(): void {
   console.log(ratioBounds(sx, sy, 1e-3)); // { lower: 0.4066..., upper: 0.5958..., unit: ... }
   console.log(disparity(sx, sy).value); // -1.694915254237288
   console.log(disparityBounds(sx, sy, 1e-3, 'demo')); // { lower: -3.1025..., upper: -0.8494..., unit: ... }
+
+  // --- Confirmatory Comparison ---
+
+  console.log(compare1(sx, [new Threshold(Metric.Center, new Measurement(50), 1e-3)])[0].verdict); // greater
+  console.log(compare2(sx, sy, [new Threshold(Metric.Shift, new Measurement(0), 1e-3)])[0].verdict); // less
 
   // --- Randomization ---
 

--- a/ts/examples/demo.ts
+++ b/ts/examples/demo.ts
@@ -16,6 +16,11 @@ import {
   Power,
   Uniform,
   Sample,
+  Measurement,
+  Metric,
+  Threshold,
+  compare1,
+  compare2,
 } from '..';
 
 function main(): void {
@@ -39,6 +44,11 @@ function main(): void {
   console.log(ratioBounds(sx, sy, 1e-3)); // { lower: 0.4066..., upper: 0.5958..., unit: ... }
   console.log(disparity(sx, sy).value); // -1.694915254237288
   console.log(disparityBounds(sx, sy, 1e-3, 'demo')); // { lower: -3.1025..., upper: -0.8494..., unit: ... }
+
+  // --- Confirmatory Comparison ---
+
+  console.log(compare1(sx, [new Threshold(Metric.Center, new Measurement(50), 1e-3)])[0].verdict); // greater
+  console.log(compare2(sx, sy, [new Threshold(Metric.Shift, new Measurement(0), 1e-3)])[0].verdict); // less
 
   // --- Randomization ---
 

--- a/ts/src/pairwiseMargin.ts
+++ b/ts/src/pairwiseMargin.ts
@@ -223,13 +223,13 @@ function binomialCoefficient(n: number, k: number): number {
   }
 
   k = Math.min(k, n - k); // Take advantage of symmetry
-  let result = 1;
+  let result = 1n; // exact integer arithmetic: each partial product is divisible
 
   for (let i = 0; i < k; i++) {
-    result = (result * (n - i)) / (i + 1);
+    result = (result * BigInt(n - i)) / BigInt(i + 1);
   }
 
-  return result;
+  return Number(result);
 }
 
 /**

--- a/ts/src/shiftImpl.ts
+++ b/ts/src/shiftImpl.ts
@@ -119,6 +119,15 @@ function selectKthPairwiseDiff(x: readonly number[], y: readonly number[], k: nu
     throw new Error('NaN in input values');
   }
 
+  // Extreme finite input can overflow the bounds to +-Infinity, making the
+  // midpoint NaN; every finite pairwise diff lies within [-MAX_VALUE, MAX_VALUE].
+  if (!isFinite(searchMin)) {
+    searchMin = Math.sign(searchMin) * Number.MAX_VALUE;
+  }
+  if (!isFinite(searchMax)) {
+    searchMax = Math.sign(searchMax) * Number.MAX_VALUE;
+  }
+
   const maxIterations = 128; // Sufficient for double precision convergence
   let prevMin = -Infinity;
   let prevMax = Infinity;

--- a/ts/src/xoshiro256.ts
+++ b/ts/src/xoshiro256.ts
@@ -87,15 +87,17 @@ export class Xoshiro256PlusPlus {
 
   /**
    * Generate a uniform integer in [min, max).
-   * @throws RangeError if max - min exceeds u64 range.
+   * @throws RangeError if the range exceeds 2^52.
    */
   uniformInt(min: bigint, max: bigint): bigint {
     if (min >= max) {
       return min;
     }
     const range = max - min;
-    if (range > 0xffffffffffffffffn) {
-      throw new RangeError('uniform_int: range overflow (max - min exceeds u64)');
+    // 2^52 is the largest range all implementations (incl. double-based R) can
+    // sample exactly; well beyond any real sample.
+    if (range > 1n << 52n) {
+      throw new RangeError('uniform_int: range exceeds 2^52');
     }
     return min + (this.nextU64() % range);
   }

--- a/ts/tests/pairwiseMarginConsistency.test.ts
+++ b/ts/tests/pairwiseMarginConsistency.test.ts
@@ -1,0 +1,10 @@
+import { pairwiseMargin } from '../src/pairwiseMargin';
+
+// Regression: the exact binomial coefficient must use integer arithmetic. Float
+// accumulation overflowed 2^53 in the partial products for C(56,27), giving a
+// margin of 784 instead of the correct 782 at misrate 1.0.
+describe('pairwiseMargin consistency', () => {
+  it('matches the exact-integer binomial (782, not float 784)', () => {
+    expect(pairwiseMargin(29, 27, 1.0)).toBe(782);
+  });
+});

--- a/ts/tests/shiftOverflow.test.ts
+++ b/ts/tests/shiftOverflow.test.ts
@@ -1,0 +1,16 @@
+import { shift } from '../src/estimators';
+
+// Regression: shift search bounds x[0]-y[n-1] and x[m-1]-y[0] can overflow to
+// +-Infinity on extreme finite input, turning the midpoint into NaN and returning
+// +-Infinity instead of the true finite shift.
+const MAX = Number.MAX_VALUE;
+
+describe('shift overflow', () => {
+  it('returns 0 for symmetric extremes', () => {
+    expect(shift([-MAX, MAX], [-MAX, MAX], true)).toBe(0);
+  });
+
+  it('returns MAX for one-sided extremes', () => {
+    expect(shift([0, MAX], [-MAX, 0], true)).toBe(MAX);
+  });
+});


### PR DESCRIPTION
Closes five cross-language correctness bugs surfaced by review, each fixed identically across all affected ports so the seven implementations agree bit-for-bit, plus the confirmatory-comparison demo. The Kotlin spread estimator now uses a Long accumulator (overflow at n>=65537); shift/ratio search bounds are clamped against overflow to infinity; the pairwise-margin binomial is computed with exact integer arithmetic in Python/TypeScript/Kotlin and a native 64-bit helper in R (whose choose() is inexact even below 2^53); C# Center/Spread now seed their RNG deterministically from the input like the other six ports; and uniform_int is made exact with a unified "range > 2^52" overflow contract. The demos exercise Compare1/Compare2 in every language with a canonical lowercase verdict.

## Appendix

Fixes are stacked one-per-commit (kt spread overflow, shift/ratio clamp, exact binomial, cs RNG determinism, uniform_int contract, demo). CI generation-drift gate and READMEs are updated alongside the demo changes.