### PR TITLE
Harden CI: pin ruff, split Dependabot majors, cover the sim crate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
 # Keep dependencies, base images, and Actions current automatically.
-# Grouped weekly PRs per ecosystem to avoid churn.
+# Grouped weekly PRs per ecosystem, but MINOR/PATCH only — major bumps come as
+# individual PRs so one breaking major can't block a group of safe updates.
 version: 2
 updates:
   - package-ecosystem: github-actions
@@ -9,6 +10,7 @@ updates:
     groups:
       actions:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: nuget
     directory: /cs
@@ -17,6 +19,7 @@ updates:
     groups:
       nuget:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: gradle
     directory: /kt
@@ -25,6 +28,11 @@ updates:
     groups:
       gradle:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
+    ignore:
+      # junit-jupiter 6.x requires JDK 17; the project pins jvmToolchain(11).
+      - dependency-name: "org.junit.jupiter:junit-jupiter"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: cargo
     directories:
@@ -36,6 +44,7 @@ updates:
     groups:
       cargo:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: gomod
     directory: /go
@@ -51,6 +60,7 @@ updates:
     groups:
       npm:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: pip
     directories:
@@ -61,6 +71,7 @@ updates:
     groups:
       pip:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: docker
     directories:
@@ -78,3 +89,11 @@ updates:
     groups:
       docker:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
+    ignore:
+      # Base images are pinned to the mise toolchain (with sync comments to the
+      # setup-* actions). Move runtime floors holistically, not via docker-only bumps.
+      - dependency-name: "python"
+      - dependency-name: "node"
+      - dependency-name: "eclipse-temurin"
+      - dependency-name: "rocker/verse"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,9 @@ jobs:
     - name: Check package
       run: mise run rs:check
 
+    - name: Check simulations
+      run: mise run rs:sim:check
+
     - name: Run tests
       run: mise run rs:test
 

--- a/mise.toml
+++ b/mise.toml
@@ -16,7 +16,9 @@ node = "22"            # sync: actions/setup-node in ci.yml (publish-npm pins 24
 # npm backend: aqua's release-asset matching is unreliable for pnpm 11.x
 "npm:pnpm" = "11"
 python = "3.12"        # sync: actions/setup-python in the workflows
-ruff = "latest"
+# Pinned, not "latest": ruff's lint set is select=ALL, so a new ruff release can
+# enable a new rule and turn CI red with zero code changes. Bump deliberately.
+ruff = "0.16.0"
 rust = "stable"
 typst = "latest"
 


### PR DESCRIPTION
Three fixes surfaced while triaging the first Dependabot wave. Pin ruff to a concrete version because its `select=ALL` lint set turns CI red whenever a new ruff release adds a rule (CPY001 and PLR0917 both did, and two ruff versions even disagreed on the same `noqa`). Restrict Dependabot groups to minor/patch so a single breaking major can no longer block a group of safe updates, ignore the junit-jupiter major (needs JDK 17 against the pinned `jvmToolchain(11)`), and ignore the toolchain base images that must move together with mise rather than via docker-only bumps. Finally, add `rs:sim:check` to the `ci-rs` job so `rs/pragmastat-sim` is actually compiled in CI — it was never built on GitHub, so its dependency bumps were passing unverified.