### PR TITLE
Point the home WEB button at Introduction

### DIFF
--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -23,7 +23,7 @@ import ThemeSwitcher from '../components/ThemeSwitcher.astro';
           The toolkit consists of renamed, recombined, and refined versions of existing methods.
         </p>
         <p class="frontpage-buttons">
-          <a href="/synopsis">HTML</a>
+          <a href="/introduction">WEB</a>
           <span class="separator">·</span>
           <a href="/pragmastat.pdf">PDF</a>
         </p>


### PR DESCRIPTION
The front-page format button linked to /synopsis and read HTML. The manual now opens with the Introduction chapter, so this points the button at /introduction and renames it to WEB (the online counterpart to the PDF button).