### PR TITLE
Fix silent content loss in the MDX generator

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -615,6 +615,28 @@ rm -rf venv
 """
 
 # ==========================================================================
+# Documentation Toolchain Tasks
+# ==========================================================================
+
+[tasks."tools:check"]
+description = "Check documentation tools (clippy, fmt, cargo check)"
+dir = "tools"
+run = """
+cargo clippy --all-targets -- -D warnings
+cargo fmt -- --check
+"""
+
+[tasks."tools:check:fix"]
+description = "Format documentation tools"
+dir = "tools"
+run = "cargo fmt"
+
+[tasks."tools:test"]
+description = "Run documentation tools tests"
+dir = "tools"
+run = "cargo test"
+
+# ==========================================================================
 # Documentation Generation Tasks
 # ==========================================================================
 
@@ -723,6 +745,8 @@ run = "cargo run --manifest-path tools/Cargo.toml --release -- clean"
 [tasks."docs:ci"]
 description = "Run documentation CI pipeline"
 run = [
+    { task = "tools:check" },
+    { task = "tools:test" },
     { task = "docs:clean" },
     { task = "docs:sync" },
     # Fail CI if regeneration left uncommitted drift in tracked generated docs

--- a/tools/src/astro.rs
+++ b/tools/src/astro.rs
@@ -76,32 +76,33 @@ pub fn convert_typst_to_mdx(
     // Skip the first heading (H1 or H2) since it's in frontmatter
     let mut skip_first_heading = true;
     for event in &document.events {
-        if skip_first_heading {
-            if let TypstEvent::Heading { level, .. } = event {
-                if *level <= 2 {
-                    skip_first_heading = false;
-                    continue;
-                }
-            }
+        if skip_first_heading
+            && let TypstEvent::Heading { level, .. } = event
+            && *level <= 2
+        {
+            skip_first_heading = false;
+            continue;
         }
         // Apply heading offset for function/distribution/implementation pages
-        if heading_offset != 0 {
-            if let TypstEvent::Heading { level, text, label } = event {
-                let adjusted = (*level as i8 + heading_offset).max(1) as u8;
-                let adjusted_event = TypstEvent::Heading {
-                    level: adjusted,
-                    text: text.clone(),
-                    label: label.clone(),
-                };
-                convert_typst_event_to_mdx(
-                    &adjusted_event,
-                    definitions,
-                    references,
-                    xref_map,
-                    &mut output,
-                );
-                continue;
-            }
+        if heading_offset != 0
+            && let TypstEvent::Heading { level, text, label } = event
+        {
+            let adjusted = (level.cast_signed() + heading_offset)
+                .max(1)
+                .cast_unsigned();
+            let adjusted_event = TypstEvent::Heading {
+                level: adjusted,
+                text: text.clone(),
+                label: label.clone(),
+            };
+            convert_typst_event_to_mdx(
+                &adjusted_event,
+                definitions,
+                references,
+                xref_map,
+                &mut output,
+            );
+            continue;
         }
         convert_typst_event_to_mdx(event, definitions, references, xref_map, &mut output);
     }
@@ -304,7 +305,10 @@ fn convert_typst_event_to_mdx(
             output.push_str("<br/>\n");
         }
         TypstEvent::HSpace(size) => {
-            let _ = write!(output, r#"<span style="display:inline-block;width:{size}"></span>"#);
+            let _ = write!(
+                output,
+                r#"<span style="display:inline-block;width:{size}"></span>"#
+            );
         }
         TypstEvent::Link { text, dest } => {
             // Convert any $...$ math in the link text to KaTeX
@@ -324,7 +328,7 @@ fn convert_typst_event_to_mdx(
     }
 }
 
-/// Convert `$...$` math fragments in text to KaTeX
+/// Convert `$...$` math fragments in text to `KaTeX`
 ///
 /// Link content blocks may contain inline math preserved as `$...$`.
 /// This function finds each fragment and converts the Typst math to LaTeX.

--- a/tools/src/astro.rs
+++ b/tools/src/astro.rs
@@ -318,7 +318,7 @@ fn convert_typst_event_to_mdx(
                 if let Some(url) = xref_map.resolve(label) {
                     let _ = write!(output, "[{converted_text}]({url})");
                 } else {
-                    eprintln!("Warning: unresolved xref: {label}");
+                    // Recorded by resolve(); the caller fails the run after generation
                     output.push_str(&converted_text);
                 }
             } else {

--- a/tools/src/bounds_width.rs
+++ b/tools/src/bounds_width.rs
@@ -65,8 +65,7 @@ pub fn generate(base_path: &Path) -> Result<()> {
         .map_err(|e| anyhow::anyhow!("Cannot read {}: {e}", json_path.display()))?;
     let all_rows: Vec<Row> = serde_json::from_str(&json_data)?;
 
-    let by_n: std::collections::HashMap<usize, &Row> =
-        all_rows.iter().map(|r| (r.n, r)).collect();
+    let by_n: std::collections::HashMap<usize, &Row> = all_rows.iter().map(|r| (r.n, r)).collect();
 
     for spec in SPECS {
         let content = build_table(&by_n, spec.get);
@@ -78,7 +77,7 @@ pub fn generate(base_path: &Path) -> Result<()> {
     let benchmark_content = build_benchmark_table(&by_n);
     let benchmark_path = base_path.join(BENCHMARK_OUTPUT);
     std::fs::write(&benchmark_path, benchmark_content)?;
-    println!("  Generated: {}", BENCHMARK_OUTPUT);
+    println!("  Generated: {BENCHMARK_OUTPUT}");
 
     Ok(())
 }

--- a/tools/src/main.rs
+++ b/tools/src/main.rs
@@ -164,6 +164,23 @@ const PAGES: &[Page] = &[
     Page { slug: "methodology", file: "methodology/methodology", title: "Methodology", order: 40, group: Some("Appendix"), heading_offset: 0 },
 ];
 
+/// Fail the run if any internal link had no entry in the cross-reference map
+///
+/// An unmapped label silently degrades its link to plain text in the generated
+/// MDX, so a miss must break the build rather than ship a broken page.
+fn ensure_xrefs_resolved(xref_map: &xref::XRefMap) -> Result<()> {
+    let unresolved = xref_map.unresolved();
+    if !unresolved.is_empty() {
+        anyhow::bail!(
+            "unresolved cross-reference(s): {}\n\
+             Each one lost its link in the generated MDX. \
+             Add the label to XRefMap in tools/src/xref.rs.",
+            unresolved.join(", ")
+        );
+    }
+    Ok(())
+}
+
 fn build_web(base_path: &Path) -> Result<()> {
     println!("Building web output...");
 
@@ -221,6 +238,8 @@ fn build_web(base_path: &Path) -> Result<()> {
         std::fs::write(web_content_path.join(&output_file), mdx_content)?;
         println!("  Generated: web/src/content/manual/{output_file}");
     }
+
+    ensure_xrefs_resolved(&xref_map)?;
 
     // Generate bibliography page (only includes actually used references)
     let bibliography_mdx =

--- a/tools/src/main.rs
+++ b/tools/src/main.rs
@@ -110,6 +110,7 @@ impl astro::AsPageInfo for Page {
     }
 }
 
+#[rustfmt::skip] // One line per page keeps this table scannable
 const PAGES: &[Page] = &[
     // Introduction
     Page { slug: "introduction", file: "introduction/introduction", title: "Introduction", order: 0, group: None, heading_offset: 0 },

--- a/tools/src/math_conv.rs
+++ b/tools/src/math_conv.rs
@@ -7,7 +7,11 @@ use std::collections::HashMap;
 use std::fmt::Write;
 
 /// Convert Typst math content to LaTeX string
-pub fn typst_to_latex(typst_math: &str, definitions: &HashMap<String, String>, display: bool) -> String {
+pub fn typst_to_latex(
+    typst_math: &str,
+    definitions: &HashMap<String, String>,
+    display: bool,
+) -> String {
     let mut result = typst_math.to_string();
 
     // Convert Typst \/ (explicit fraction) depending on display mode
@@ -78,7 +82,7 @@ fn apply_definitions_outside_text(input: &str, definitions: &HashMap<String, Str
 
     // Apply definitions to the result (which now has placeholders instead of \text{} blocks)
     let mut sorted_defs: Vec<_> = definitions.iter().collect();
-    sorted_defs.sort_by(|(a, _), (b, _)| b.len().cmp(&a.len()));
+    sorted_defs.sort_by_key(|(name, _)| std::cmp::Reverse(name.len()));
 
     for (name, latex) in sorted_defs {
         // Skip single letters - they cause too many false matches
@@ -741,8 +745,7 @@ fn convert_syntax(input: &str, display: bool) -> String {
                 let bytes = result.as_bytes();
 
                 // Check if preceded by backslash (already converted, e.g., \sigma)
-                let preceded_by_backslash =
-                    m.start() > 0 && bytes[m.start() - 1] == b'\\';
+                let preceded_by_backslash = m.start() > 0 && bytes[m.start() - 1] == b'\\';
 
                 // Check if embedded in a larger word (preceded by letter)
                 let preceded_by_letter =
@@ -1106,6 +1109,9 @@ fn strip_outer_parens(s: &str) -> &str {
 
 /// Find the fraction numerator (content before /)
 /// Returns (start, end) indices of the numerator
+// Single backward scanner over the character stream: splitting the bracket/function
+// state across helpers would spread one state machine over several signatures.
+#[allow(clippy::too_many_lines)]
 fn find_fraction_part_before(chars: &[char], slash_pos: usize) -> Option<(usize, usize)> {
     if slash_pos == 0 {
         return None;
@@ -1283,6 +1289,8 @@ fn find_fraction_part_before(chars: &[char], slash_pos: usize) -> Option<(usize,
 
 /// Find the fraction denominator (content after /)
 /// Returns (start, end) indices of the denominator
+// Forward mirror of `find_fraction_part_before`; kept as one scanner for the same reason.
+#[allow(clippy::too_many_lines)]
 fn find_fraction_part_after(chars: &[char], start_pos: usize) -> Option<(usize, usize)> {
     if start_pos >= chars.len() {
         return None;
@@ -1497,7 +1505,9 @@ fn wrap_multichar_scripts(input: &str, prefix: &str) -> String {
         if chars[i..].starts_with(&prefix_chars) {
             let after = i + prefix_chars.len();
             // Skip if already braced or parenthesized or followed by backslash (LaTeX command)
-            if after < chars.len() && (chars[after] == '{' || chars[after] == '(' || chars[after] == '\\') {
+            if after < chars.len()
+                && (chars[after] == '{' || chars[after] == '(' || chars[after] == '\\')
+            {
                 result.push(chars[i]);
                 i += 1;
                 continue;
@@ -2214,7 +2224,10 @@ mod tests {
         assert_eq!(typst_to_latex("pmean", &defs, true), "\\mathrm{mean}");
         assert_eq!(typst_to_latex("pstddev", &defs, true), "\\mathrm{stdDev}");
         assert_eq!(typst_to_latex("plogmean", &defs, true), "\\mathrm{logMean}");
-        assert_eq!(typst_to_latex("plogstddev", &defs, true), "\\mathrm{logStdDev}");
+        assert_eq!(
+            typst_to_latex("plogstddev", &defs, true),
+            "\\mathrm{logStdDev}"
+        );
         assert_eq!(typst_to_latex("pmin", &defs, true), "\\mathrm{min}");
         assert_eq!(typst_to_latex("pmax", &defs, true), "\\mathrm{max}");
         assert_eq!(typst_to_latex("pshape", &defs, true), "\\mathrm{shape}");
@@ -2374,7 +2387,11 @@ mod tests {
     fn convert_splitmix64_formula() {
         let defs = HashMap::new();
         // Test the actual formula from the randomization chapter
-        let result = typst_to_latex("x <- (x xor (x >> 30)) times \"0xbf58476d1ce4e5b9\"", &defs, true);
+        let result = typst_to_latex(
+            "x <- (x xor (x >> 30)) times \"0xbf58476d1ce4e5b9\"",
+            &defs,
+            true,
+        );
         eprintln!("Result: {result}");
         assert!(
             result.contains("\\leftarrow"),
@@ -2498,7 +2515,9 @@ mod tests {
 
         // Should create a proper fraction with superscripts intact
         assert!(
-            result.contains("\\frac{\\operatorname{Drift}^2(T_2, X)}{\\operatorname{Drift}^2(T_1, X)}"),
+            result.contains(
+                "\\frac{\\operatorname{Drift}^2(T_2, X)}{\\operatorname{Drift}^2(T_1, X)}"
+            ),
             "Superscript function calls should be proper fraction parts: {result}"
         );
 
@@ -2515,8 +2534,11 @@ mod tests {
         let mut defs = HashMap::new();
         defs.insert("Drift".to_string(), "\\operatorname{Drift}".to_string());
 
-        let result =
-            typst_to_latex("n_\"new\" = n_\"original\" dot Drift^2(T_2, X) / Drift^2(T_1, X)", &defs, true);
+        let result = typst_to_latex(
+            "n_\"new\" = n_\"original\" dot Drift^2(T_2, X) / Drift^2(T_1, X)",
+            &defs,
+            true,
+        );
         eprintln!("Result: {result}");
 
         // Should have proper text subscripts
@@ -2531,7 +2553,9 @@ mod tests {
 
         // Should have proper fraction
         assert!(
-            result.contains("\\frac{\\operatorname{Drift}^2(T_2, X)}{\\operatorname{Drift}^2(T_1, X)}"),
+            result.contains(
+                "\\frac{\\operatorname{Drift}^2(T_2, X)}{\\operatorname{Drift}^2(T_1, X)}"
+            ),
             "Should have proper fraction with Drift^2: {result}"
         );
     }
@@ -2596,15 +2620,24 @@ mod tests {
 
         // "thesigma" should stay as-is (sigma is embedded)
         let result = typst_to_latex("thesigma", &defs, true);
-        assert_eq!(result, "thesigma", "Embedded sigma should not convert: {result}");
+        assert_eq!(
+            result, "thesigma",
+            "Embedded sigma should not convert: {result}"
+        );
 
         // "sigmaX" should stay as-is (sigma followed by letter)
         let result = typst_to_latex("sigmaX", &defs, true);
-        assert_eq!(result, "sigmaX", "sigma followed by letter should not convert: {result}");
+        assert_eq!(
+            result, "sigmaX",
+            "sigma followed by letter should not convert: {result}"
+        );
 
         // But "sigma X" should convert (space separator)
         let result = typst_to_latex("sigma X", &defs, true);
-        assert_eq!(result, "\\sigma X", "sigma with space should convert: {result}");
+        assert_eq!(
+            result, "\\sigma X",
+            "sigma with space should convert: {result}"
+        );
     }
 
     #[test]
@@ -2621,7 +2654,10 @@ mod tests {
     fn greek_with_operators_converts() {
         // Greek letters adjacent to operators should convert
         let defs = HashMap::new();
-        assert_eq!(typst_to_latex("sigma + tau", &defs, true), "\\sigma + \\tau");
+        assert_eq!(
+            typst_to_latex("sigma + tau", &defs, true),
+            "\\sigma + \\tau"
+        );
         assert_eq!(typst_to_latex("(sigma)", &defs, true), "(\\sigma)");
         assert_eq!(typst_to_latex("sigma,tau", &defs, true), "\\sigma,\\tau");
     }
@@ -2662,8 +2698,14 @@ mod tests {
     fn inline_complex_fraction_stays_flat() {
         let defs = HashMap::new();
         let result = typst_to_latex("(a + b) / 2", &defs, false);
-        assert!(!result.contains("\\frac"), "Inline should not produce \\frac: {result}");
-        assert!(result.contains("/"), "Inline should keep flat slash: {result}");
+        assert!(
+            !result.contains("\\frac"),
+            "Inline should not produce \\frac: {result}"
+        );
+        assert!(
+            result.contains('/'),
+            "Inline should keep flat slash: {result}"
+        );
     }
 
     #[test]

--- a/tools/src/templates.rs
+++ b/tools/src/templates.rs
@@ -163,7 +163,8 @@ pub fn sync_templates(base_path: &Path, version: &str) -> Result<()> {
 
 fn generate_readme(lang: &Language, version: &str, demo: &str) -> String {
     let major = version.split('.').next().unwrap_or(version);
-    let install = lang.install_md
+    let install = lang
+        .install_md
         .replace("{version}", version)
         .replace("{major}", major);
     let source_url = format!(

--- a/tools/src/typst_eval.rs
+++ b/tools/src/typst_eval.rs
@@ -83,6 +83,8 @@ impl EvalContext {
 }
 
 /// Parse the definitions.typ file and extract variables
+// One linear pass over the file; the per-construct branches share the cursor state.
+#[allow(clippy::too_many_lines)]
 pub fn parse_definitions(path: &Path) -> Result<EvalContext> {
     let content = std::fs::read_to_string(path)?;
     let base_path = path.parent().unwrap_or(Path::new("."));
@@ -146,9 +148,7 @@ pub fn parse_definitions(path: &Path) -> Result<EvalContext> {
                     import_vars.push("*".to_string());
                     i += 1;
                 } else {
-                    while i < chars.len()
-                        && (chars[i].is_alphanumeric() || chars[i] == '_')
-                    {
+                    while i < chars.len() && (chars[i].is_alphanumeric() || chars[i] == '_') {
                         i += 1;
                     }
                     import_vars.push(chars_to_string(var_start, i));
@@ -168,9 +168,7 @@ pub fn parse_definitions(path: &Path) -> Result<EvalContext> {
                             i += 1;
                         }
                         let next_start = i;
-                        while i < chars.len()
-                            && (chars[i].is_alphanumeric() || chars[i] == '_')
-                        {
+                        while i < chars.len() && (chars[i].is_alphanumeric() || chars[i] == '_') {
                             i += 1;
                         }
                         if i > next_start {

--- a/tools/src/typst_parser.rs
+++ b/tools/src/typst_parser.rs
@@ -696,8 +696,11 @@ fn resolve_includes(content: &str, current_dir: &Path) -> Result<String> {
 
         if directive_type == "typst" {
             // Handle #include "path.typ"
-            let after_include = &remaining[start + 8..];
-            let after_include = after_include.trim_start();
+            let after_include_raw = &remaining[start + 8..];
+            let after_include = after_include_raw.trim_start();
+            // Offsets below are relative to the trimmed slice, so the skipped
+            // whitespace has to be added back when advancing `remaining`
+            let trim_offset = after_include_raw.len() - after_include.len();
 
             // Find the quoted path
             if let Some(quote_start) = after_include.find('"') {
@@ -718,7 +721,8 @@ fn resolve_includes(content: &str, current_dir: &Path) -> Result<String> {
                     result.push('\n');
 
                     // Move past the include directive
-                    remaining = &remaining[start + 8 + quote_start + 1 + quote_end + 1..];
+                    remaining =
+                        &remaining[start + 8 + trim_offset + quote_start + 1 + quote_end + 1..];
                     continue;
                 }
             }
@@ -1407,6 +1411,30 @@ mod tests {
     use super::*;
     use crate::typst_eval::TypstValue;
     use std::collections::HashMap;
+
+    #[test]
+    fn resolve_includes_consumes_whole_directive() {
+        // A space between #include and the path used to be dropped from the offset
+        // arithmetic, leaving the closing quote behind in the output
+        let dir = std::env::temp_dir().join("pragmastat-include-test");
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let included = dir.join("part.typ");
+        std::fs::write(&included, "included body\n").expect("write include");
+
+        let resolved = resolve_includes("before\n#include \"part.typ\"\nafter\n", &dir)
+            .expect("resolve includes");
+
+        std::fs::remove_file(&included).ok();
+        std::fs::remove_dir(&dir).ok();
+
+        assert!(
+            !resolved.contains('"'),
+            "directive leftovers in output: {resolved:?}"
+        );
+        assert!(resolved.contains("included body"));
+        assert!(resolved.contains("before"));
+        assert!(resolved.contains("after"));
+    }
 
     #[test]
     fn markup_shorthands_and_quotes_survive() {

--- a/tools/src/typst_parser.rs
+++ b/tools/src/typst_parser.rs
@@ -1085,9 +1085,8 @@ fn parse_node(node: &SyntaxNode, events: &mut Vec<TypstEvent>, list_depth: u8) {
                                 ast::Arg::Pos(ast::Expr::Label(label)) => {
                                     // Internal link: #link(<label-name>)
                                     let label_text = label.to_untyped().leaf_text();
-                                    let label_name = label_text
-                                        .trim_start_matches('<')
-                                        .trim_end_matches('>');
+                                    let label_name =
+                                        label_text.trim_start_matches('<').trim_end_matches('>');
                                     dest = format!("internal:{label_name}");
                                 }
                                 _ => {}
@@ -1174,11 +1173,7 @@ fn parse_node(node: &SyntaxNode, events: &mut Vec<TypstEvent>, list_depth: u8) {
                             match arg {
                                 ast::Arg::Pos(ast::Expr::ContentBlock(content)) => {
                                     let mut item_content = Vec::new();
-                                    parse_node(
-                                        content.body().to_untyped(),
-                                        &mut item_content,
-                                        0,
-                                    );
+                                    parse_node(content.body().to_untyped(), &mut item_content, 0);
                                     events.push(TypstEvent::ListItem {
                                         depth: 1,
                                         content: item_content,
@@ -1814,7 +1809,7 @@ Some text after."#,
 
     #[test]
     fn parse_internal_link() {
-        let content = r#"See #link(<ch-algorithms>)[Algorithms] for details."#;
+        let content = r"See #link(<ch-algorithms>)[Algorithms] for details.";
         let events = parse_typst_content(content);
         let link = events.iter().find_map(|e| {
             if let TypstEvent::Link { text, dest } = e {

--- a/tools/src/typst_parser.rs
+++ b/tools/src/typst_parser.rs
@@ -951,6 +951,20 @@ fn parse_node(node: &SyntaxNode, events: &mut Vec<TypstEvent>, list_depth: u8) {
             // Handle forced line breaks (\ at end of line in Typst)
             events.push(TypstEvent::Linebreak);
         }
+        SyntaxKind::Shorthand => {
+            // Markup shorthands (--- em dash, -- en dash, ... ellipsis, ~ nbsp).
+            // These are leaf nodes, so the catch-all arm would drop them silently.
+            if let Some(shorthand) = node.cast::<ast::Shorthand>() {
+                events.push(TypstEvent::Text(shorthand.get().to_string()));
+            }
+        }
+        SyntaxKind::SmartQuote => {
+            if let Some(quote) = node.cast::<ast::SmartQuote>() {
+                events.push(TypstEvent::Text(
+                    if quote.double() { "\"" } else { "'" }.to_string(),
+                ));
+            }
+        }
         SyntaxKind::Raw => {
             if let Some(raw) = node.cast::<ast::Raw>() {
                 // to_untyped().leaf_text() only returns the node's direct text, not its children
@@ -1263,6 +1277,17 @@ fn extract_text_recursive_inner(node: &SyntaxNode, text: &mut String, preserve_m
                 text.push_str(escaped);
             }
         }
+        SyntaxKind::Shorthand => {
+            // Same leaf-node problem as in parse_node; headings and alt text go through here
+            if let Some(shorthand) = node.cast::<ast::Shorthand>() {
+                text.push(shorthand.get());
+            }
+        }
+        SyntaxKind::SmartQuote => {
+            if let Some(quote) = node.cast::<ast::SmartQuote>() {
+                text.push(if quote.double() { '"' } else { '\'' });
+            }
+        }
         SyntaxKind::Equation if preserve_math => {
             // Preserve inline math as $...$ so the MDX converter can process it
             // Use equation body to avoid including the $ delimiters twice
@@ -1382,6 +1407,20 @@ mod tests {
     use super::*;
     use crate::typst_eval::TypstValue;
     use std::collections::HashMap;
+
+    #[test]
+    fn markup_shorthands_and_quotes_survive() {
+        let events = parse_typst_content("A --- B and the \"quoted\" word");
+        let text: String = events
+            .iter()
+            .filter_map(|e| match e {
+                TypstEvent::Text(t) => Some(t.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert!(text.contains('\u{2014}'), "em dash lost: {text:?}");
+        assert!(text.contains("\"quoted\""), "quotes lost: {text:?}");
+    }
 
     #[test]
     fn preprocess_let_binding() {

--- a/tools/src/version.rs
+++ b/tools/src/version.rs
@@ -120,7 +120,8 @@ pub fn sync_versions(base_path: &Path, version: &str) -> Result<()> {
         }
 
         let major = version.split('.').next().unwrap_or(version);
-        let replacement = target.replacement
+        let replacement = target
+            .replacement
             .replace("{version}", version)
             .replace("{major}", major);
         let updated = regex.replace_all(&content, replacement.as_str());

--- a/tools/src/xref.rs
+++ b/tools/src/xref.rs
@@ -1,10 +1,15 @@
-use std::collections::HashMap;
+use std::cell::RefCell;
+use std::collections::{BTreeSet, HashMap};
 
 /// Cross-reference mapping for internal links
 ///
 /// Maps Typst label names (e.g., "sec-alg-center") to web URLs (e.g., "/center#algorithm")
+///
+/// Lookups that miss are recorded so that generation can fail on them instead of
+/// silently degrading the link to plain text.
 pub struct XRefMap {
     mappings: HashMap<String, String>,
+    unresolved: RefCell<BTreeSet<String>>,
 }
 
 impl XRefMap {
@@ -141,15 +146,29 @@ impl XRefMap {
             "/center-bounds#on-misrate-efficiency-of-medianbounds".into(),
         );
 
-        Self { mappings }
+        Self {
+            mappings,
+            unresolved: RefCell::new(BTreeSet::new()),
+        }
     }
 
     /// Resolve an internal label to its web URL
     ///
-    /// Returns `None` if the label is not found
+    /// Returns `None` if the label is not found, recording the label so that
+    /// [`XRefMap::unresolved`] can report it afterwards.
     #[must_use]
     pub fn resolve(&self, label: &str) -> Option<&str> {
-        self.mappings.get(label).map(String::as_str)
+        let resolved = self.mappings.get(label).map(String::as_str);
+        if resolved.is_none() {
+            self.unresolved.borrow_mut().insert(label.to_owned());
+        }
+        resolved
+    }
+
+    /// Labels that [`XRefMap::resolve`] failed to look up, sorted and deduplicated
+    #[must_use]
+    pub fn unresolved(&self) -> Vec<String> {
+        self.unresolved.borrow().iter().cloned().collect()
     }
 }
 
@@ -189,5 +208,20 @@ mod tests {
     fn resolve_unknown_label() {
         let xref = XRefMap::new();
         assert_eq!(xref.resolve("unknown-label"), None);
+    }
+
+    #[test]
+    fn unresolved_starts_empty_and_records_misses() {
+        let xref = XRefMap::new();
+        assert!(xref.unresolved().is_empty());
+
+        assert_eq!(xref.resolve("sec-assumptions"), Some("/assumptions"));
+        assert!(xref.unresolved().is_empty());
+
+        assert_eq!(xref.resolve("sec-nope"), None);
+        assert_eq!(xref.resolve("sec-nope"), None);
+        assert_eq!(xref.resolve("sec-also-nope"), None);
+
+        assert_eq!(xref.unresolved(), vec!["sec-also-nope", "sec-nope"]);
     }
 }

--- a/tools/src/xref.rs
+++ b/tools/src/xref.rs
@@ -9,6 +9,8 @@ pub struct XRefMap {
 
 impl XRefMap {
     /// Create a new cross-reference map with predefined mappings
+    // Flat label-to-URL table: length tracks the number of labels, not complexity.
+    #[allow(clippy::too_many_lines)]
     #[must_use]
     pub fn new() -> Self {
         let mut mappings = HashMap::new();
@@ -94,37 +96,19 @@ impl XRefMap {
             "sec-alg-ratio-bounds".into(),
             "/ratio-bounds#algorithm".into(),
         );
-        mappings.insert(
-            "sec-alg-disparity".into(),
-            "/disparity#algorithm".into(),
-        );
+        mappings.insert("sec-alg-disparity".into(), "/disparity#algorithm".into());
         mappings.insert(
             "sec-alg-disparity-bounds".into(),
             "/disparity-bounds#algorithm".into(),
         );
-        mappings.insert(
-            "sec-alg-compare1".into(),
-            "/compare1#algorithm".into(),
-        );
-        mappings.insert(
-            "sec-alg-compare2".into(),
-            "/compare2#algorithm".into(),
-        );
+        mappings.insert("sec-alg-compare1".into(), "/compare1#algorithm".into());
+        mappings.insert("sec-alg-compare2".into(), "/compare2#algorithm".into());
         mappings.insert("sec-alg-rng".into(), "/rng#algorithm".into());
-        mappings.insert(
-            "sec-alg-uniform".into(),
-            "/uniform-float#algorithm".into(),
-        );
+        mappings.insert("sec-alg-uniform".into(), "/uniform-float#algorithm".into());
         mappings.insert("sec-alg-sample".into(), "/sample#algorithm".into());
         mappings.insert("sec-alg-shuffle".into(), "/shuffle#algorithm".into());
-        mappings.insert(
-            "sec-alg-resample".into(),
-            "/resample#algorithm".into(),
-        );
-        mappings.insert(
-            "sec-alg-avg-spread".into(),
-            "/avg-spread#algorithm".into(),
-        );
+        mappings.insert("sec-alg-resample".into(), "/resample#algorithm".into());
+        mappings.insert("sec-alg-avg-spread".into(), "/avg-spread#algorithm".into());
         mappings.insert(
             "sec-alg-avg-spread-bounds".into(),
             "/avg-spread-bounds#algorithm".into(),
@@ -189,10 +173,7 @@ mod tests {
     fn resolve_algorithm_label() {
         let xref = XRefMap::new();
         assert_eq!(xref.resolve("sec-alg-center"), Some("/center#algorithm"));
-        assert_eq!(
-            xref.resolve("sec-alg-rng"),
-            Some("/rng#algorithm")
-        );
+        assert_eq!(xref.resolve("sec-alg-rng"), Some("/rng#algorithm"));
     }
 
     #[test]


### PR DESCRIPTION
The Typst-to-MDX converter was dropping characters and broken links without failing: `Shorthand` and `SmartQuote` are leaf nodes that the catch-all arm walked straight past, an off-by-one in `resolve_includes` left a stray quote in the stream, and an unmapped cross-reference only produced a stderr warning while the link degraded to plain text. Across the manual this restored 96 em dashes, 244 quotes and apostrophes, two en dashes, one minus sign that had turned "bounds around -2" into "bounds around 2", and removed 96 stray blank lines; unresolved references now fail the build. The crate also declared `clippy::all + pedantic = deny` but no task ever ran it, so this adds `tools:check`/`tools:test`, wires them into `docs:ci`, and clears the 14 violations that had accumulated.

## Appendix

The two parser bugs were masking each other: the leftover quote from `resolve_includes` became a `SmartQuote` node, which was then discarded along with every other quote. Fixing the quotes alone made ten pages sprout an orphan `"` on its own line.

Verified by generating the site with the old and new binaries over identical sources and diffing: after normalizing the five affected glyph classes the outputs are byte-identical, so nothing else moved. Word count went from 57919 to 58015, exactly the restored characters.

`mise run docs:ci` passes with the new gates, as do `cs`, `go`, `kt`, `rs`, `ts` and `r`. `py:check` fails locally for an unrelated reason described below; GitHub CI on `main` is green.

Two pre-existing issues found along the way, both out of scope here:

- `py:restore` pip-installs `ruff` into the mise Python prefix, and that binary (0.15.20) shadows the version pinned in `mise.toml` (0.16.0) on `PATH`. Under the pinned version `py/` is clean; under the shadowing one three `noqa: PLR0917` directives read as unused.
- `Fisher-Yates` is spelled with a hyphen in three places and an en dash shorthand in two, which is now visible on the rendered pages. Handled separately.