### PR TITLE
Correct math errors in the manual and document the weak shape assumption

### DIFF
--- a/manual/additive/additive-notes.typ
+++ b/manual/additive/additive-notes.typ
@@ -3,9 +3,9 @@
 The $Additive$ ('Normal') distribution has two parameters: the mean and the standard deviation,
 written as $Additive(pmean, pstddev)$.
 
-==== Sampling (Box-Muller Transform)
+==== Sampling (Box--Muller Transform)
 
-The toolkit samples $Additive$ values using the Box-Muller transform (see @boxmuller1958),
+The toolkit samples $Additive$ values using the Box--Muller transform (see @boxmuller1958),
 which converts two independent $UniformFloat$ draws into standard normal values.
 Given $U_1, U_2 in [0, 1)$:
 

--- a/manual/additive/additive.typ
+++ b/manual/additive/additive.typ
@@ -9,7 +9,7 @@ $ Additive(pmean, pstddev) $
 
 #image("/img/distribution-additive_light.png")
 
-- *Formation:* the sum of many variables $X_1 + X_2 + ... + X_n$ under mild CLT (Central Limit Theorem) conditions (e.g., Lindeberg-Feller).
+- *Formation:* the sum of many variables $X_1 + X_2 + ... + X_n$ under mild CLT (Central Limit Theorem) conditions (e.g., Lindeberg--Feller).
 - *Origin:* historically called 'Normal' or 'Gaussian' distribution after Carl Friedrich Gauss and others.
 - *Rename Motivation:* renamed to $Additive$ to reflect its formation mechanism through addition.
 - *Properties:* symmetric, bell-shaped, characterized by central limit theorem convergence.

--- a/manual/assumptions/assumptions.typ
+++ b/manual/assumptions/assumptions.typ
@@ -180,6 +180,71 @@ Weak symmetry is a performance expectation, not an enforced constraint:
 #link(<sec-center-bounds>)[$CenterBounds$] requires both weak continuity and weak symmetry for exact coverage.
 
 #pagebreak()
+== Weak Shape Assumption <sec-weak-shape>
+
+*Definition*
+
+Two-sample bounds assume the compared distributions share the same shape
+and differ only in location: $F_X (t) = F_Y (t - Delta)$, equivalently $X =^d Y + Delta$.
+The unknown $Delta$ is the target parameter; nothing else about the common shape is assumed.
+
+*Properties*
+
+Weak shape is a performance expectation, not an enforced constraint:
+
+#v(0.3em)
+#list(marker: none, tight: true,
+  [*Approximate shape match* — The shapes need not match exactly;
+  mild differences produce mild coverage drift.],
+  [*Distribution-free within the model* — Coverage is exact for every continuous
+  $F_X$ that satisfies the model, whatever its shape.],
+  [*Not validated* — This is a modeling assumption, never checked computationally.],
+  [*Violation behavior* — When the shapes differ (unequal dispersion, for example),
+  the actual coverage may deviate from $1 - misrate$.],
+)
+
+#v(0.5em)
+*Multiplicative form*
+
+#link(<sec-ratio-bounds>)[$RatioBounds$] applies the same model in log-space,
+where it becomes multiplicative: the distributions must differ only by scale,
+$F_X (t) = F_Y (t \/ theta)$, equivalently $X =^d theta Y$ with $theta > 0$.
+
+#v(0.5em)
+*When shape agreement is plausible*
+
+#list(marker: none, tight: true,
+  [Before/after comparisons where the change moves the level, not the variability],
+  [Repeated benchmarks of two builds measured under identical conditions],
+  [Two arms of the same instrumented process],
+)
+
+#v(0.5em)
+*When shape agreement is doubtful*
+
+#list(marker: none, tight: true,
+  [Groups with visibly different dispersion],
+  [Samples truncated, censored, or rounded differently from each other],
+  [Mixtures where only one group carries a slow tail],
+)
+
+#v(0.5em)
+*Functions requiring weak shape*
+
+#list(marker: none, tight: true,
+  [#link(<sec-shift-bounds>)[$ShiftBounds(vx, vy, misrate)$] — requires weak shape for exact coverage.],
+  [#link(<sec-ratio-bounds>)[$RatioBounds(vx, vy, misrate)$] — requires the multiplicative form for exact coverage.],
+  [#link(<sec-disparity-bounds>)[$DisparityBounds(vx, vy, misrate)$] — inherits weak shape from its $ShiftBounds$ component.],
+)
+
+#v(0.5em)
+*Relationship to weak symmetry*
+
+The two assumptions are independent.
+#link(<sec-center-bounds>)[$CenterBounds$] needs one distribution to be symmetric;
+two-sample bounds need two distributions to agree in shape, with no symmetry requirement on either.
+
+#pagebreak()
 == Sparity Assumption <sec-sparity>
 
 *Definition*
@@ -194,7 +259,7 @@ This can happen even when `min(x) < max(x)`, so a min/max check is not sufficien
 
 *Why it matters*
 
-#link(<sec-spread>)[Spread] is defined as the median of pairwise differences.
+#link(<sec-spread>)[Spread] is defined as the median of pairwise absolute differences.
 If the median is zero, variability is not just small — it is not identifiable at the toolkit's scale.
 The sparity assumption captures this and prevents tie-dominant samples from entering spread-based estimators.
 

--- a/manual/center-bounds/center-bounds.typ
+++ b/manual/center-bounds/center-bounds.typ
@@ -30,7 +30,7 @@ Robust bounds on #link(<sec-center>)[$Center(vx)$] with specified coverage.
 *Notes*
 
 #list(marker: none, tight: true,
-  [*Also known as* — Wilcoxon signed-rank confidence interval for Hodges-Lehmann pseudomedian],
+  [*Also known as* — Wilcoxon signed-rank confidence interval for Hodges--Lehmann pseudomedian],
   [*Note* — assumes #link(<sec-weak-symmetry>)[weak symmetry] and weak continuity; exact for $n <= 63$, Edgeworth approximation for $n > 63$],
 )
 

--- a/manual/center/center-notes.typ
+++ b/manual/center/center-notes.typ
@@ -14,7 +14,7 @@ $ Median(vx) = cases(
   (x_((n\/2)) + x_((n\/2+1))) / 2 & "if" n "is even"
 ) $
 
-*Center* (Hodges-Lehmann estimator):
+*Center* (Hodges--Lehmann estimator):
 $ Center(vx) = attach(Median, b: 1 <= i <= j <= n) ((x_i + x_j) / 2) $
 
 ==== Breakdown

--- a/manual/center/center-notes.typ
+++ b/manual/center/center-notes.typ
@@ -52,7 +52,8 @@ The $Center$ estimator achieves a $29%$ breakdown point,
 ==== Drift
 
 Drift measures estimator precision by quantifying how much estimates scatter across repeated samples.
-It is based on the $Spread$ of estimates and therefore has a breakdown point of approximately $29%$.
+It is based on the $Spread$ of estimates, so its empirical evaluation across repeated samples
+  inherits the $29%$ breakdown point of $Spread$.
 
 Drift is useful for comparing the precision of several estimators.
 To simplify the comparison, one of the estimators can be chosen as a baseline.

--- a/manual/center/center.typ
+++ b/manual/center/center.typ
@@ -25,7 +25,7 @@ Robust measure of location (central tendency).
 *Notes*
 
 #list(marker: none, tight: true,
-  [*Also known as* — Hodges-Lehmann estimator, pseudomedian],
+  [*Also known as* — Hodges--Lehmann estimator, pseudomedian],
   [*Complexity* — $O(n log n)$],
 )
 

--- a/manual/disparity-bounds/disparity-bounds.typ
+++ b/manual/disparity-bounds/disparity-bounds.typ
@@ -31,7 +31,7 @@ Robust bounds on #link(<sec-disparity>)[$Disparity(vx, vy)$] with specified cove
 *Notes*
 
 #list(marker: none, tight: true,
-  [*Note* --- Bonferroni split between shift and avg-spread bounds; no independence assumption needed; bounds may be unbounded when pooled spread cannot be certified positive],
+  [*Note* --- Bonferroni split between shift and avg-spread bounds; inherits #link(<sec-weak-shape>)[weak shape] from the shift component; no independence assumption needed; bounds may be unbounded when pooled spread cannot be certified positive],
 )
 
 #v(0.5em)

--- a/manual/foundations/foundations-synopsis.typ
+++ b/manual/foundations/foundations-synopsis.typ
@@ -147,7 +147,7 @@ This simple inversion provides several advantages:
 The terminology shift from "confidence level" to "misrate"
   parallels other clarifying renames in this toolkit.
 Just as $Additive$ better describes the distribution's formation than 'Normal',
-  and #link(<sec-center>)[$Center$] better describes the estimator's purpose than 'Hodges-Lehmann',
+  and #link(<sec-center>)[$Center$] better describes the estimator's purpose than 'Hodges--Lehmann',
   $misrate$ better describes the quantity practitioners actually reason about:
   the probability of error.
 

--- a/manual/methodology/methodology.typ
+++ b/manual/methodology/methodology.typ
@@ -197,7 +197,7 @@ Names in this toolkit encode operational knowledge rather than historical proven
   [Gaussian / Normal], [$Additive$], [Formation: sum of independent factors (CLT)],
   [Log-normal / Galton], [$Multiplic$], [Formation: product of independent factors],
   [Pareto], [$Power$], [Behavior: power-law relationship],
-  [Hodges-Lehmann], [$Center$], [Function: measures central tendency],
+  [Hodges--Lehmann], [$Center$], [Function: measures central tendency],
   [Shamos], [$Spread$], [Function: measures variability],
   [(none)], [sparity], [Assumption: property of having positive spread],
 )

--- a/manual/methodology/methodology.typ
+++ b/manual/methodology/methodology.typ
@@ -129,7 +129,8 @@ This is deliberate: a tradeoff between robustness and precision.
 
 #v(0.5em)
 The 29% breakdown point survives approximately one corrupted measurement in four
-while maintaining roughly 95% asymptotic efficiency under ideal Gaussian conditions.
+while maintaining high asymptotic efficiency under ideal Gaussian conditions
+  (about 95% for $Center$ and 86% for $Spread$).
 This represents the practical optimum: enough robustness for realistic contamination levels,
 enough efficiency to compete with traditional methods when data is clean.
 
@@ -464,7 +465,7 @@ For one-sample bounds, minimum achievable misrate $= 2^(1-n)$:
   [5], [0.0625], [93.75%], [cannot achieve 95%],
   [7], [0.0156], [98.4%], [cannot achieve 99%],
   [10], [0.00195], [99.8%], [most practical misrates achievable],
-  [20], [$1.9 times 10^(-6)$], [99.9998%], [$misrate = 10^(-6)$ is achievable],
+  [21], [$9.5 times 10^(-7)$], [99.9999%], [$misrate = 10^(-6)$ is achievable],
   table.hline(),
 )
 
@@ -473,7 +474,7 @@ For one-sample bounds, minimum achievable misrate $= 2^(1-n)$:
 
 #list(marker: none, tight: true,
   [$n < 11$: Cannot achieve 99.9% confidence ($misrate = 10^(-3)$)],
-  [$n >= 20$: $misrate = 10^(-6)$ is achievable],
+  [$n >= 21$: $misrate = 10^(-6)$ is achievable],
 )
 
 #v(0.5em)

--- a/manual/pairwise-margin/pairwise-margin-algorithm.typ
+++ b/manual/pairwise-margin/pairwise-margin-algorithm.typ
@@ -250,7 +250,7 @@ The table below shows $misrate_min$ for small sample sizes:
   table.hline(),
 )
 
-For meaningful bounds construction, choose $misrate > misrate_min$.
+For meaningful bounds construction, choose $misrate >= misrate_min$.
 This ensures the margin function excludes at least some extreme pairwise differences,
   producing bounds narrower than the full range.
 When working with small samples, verify that the desired misrate exceeds $misrate_min$

--- a/manual/pairwise-margin/pairwise-margin-notes.typ
+++ b/manual/pairwise-margin/pairwise-margin-notes.typ
@@ -1,6 +1,6 @@
 #import "/manual/definitions.typ": *
 
-The Mann-Whitney $U$ test (also known as the Wilcoxon rank-sum test)
+The Mann--Whitney $U$ test (also known as the Wilcoxon rank-sum test)
   ranks among the most widely used non-parametric statistical tests,
   testing whether two independent samples come from the same distribution.
 Under $Additive$ (Normal) conditions, it achieves nearly the same precision as the Student's $t$-test,
@@ -8,7 +8,7 @@ Under $Additive$ (Normal) conditions, it achieves nearly the same precision as t
 
 The test operates by comparing all pairs of measurements between the two samples.
 Given samples $vx = (x_1, ..., x_n)$ and $vy = (y_1, ..., y_m)$,
-  the Mann-Whitney $U$ statistic counts how many pairs satisfy $x_i > y_j$:
+  the Mann--Whitney $U$ statistic counts how many pairs satisfy $x_i > y_j$:
 
 $ U = sum_(i=1)^n sum_(j=1)^m bb(1)(x_i > y_j) $
 
@@ -45,7 +45,7 @@ This inversion transforms hypothesis testing into bounds estimation.
 The mathematical foundation remains the same.
 The distribution of pairwise comparisons under random sampling determines
   which order statistics of pairwise differences form reliable bounds.
-The Mann-Whitney $U$ statistic measures pairwise comparisons ($x_i > y_j$).
+The Mann--Whitney $U$ statistic measures pairwise comparisons ($x_i > y_j$).
 The $Shift$ estimator uses pairwise differences ($x_i - y_j$).
 These quantities are mathematically related:
   a pairwise difference $x_i - y_j$ is positive exactly when $x_i > y_j$.
@@ -96,7 +96,7 @@ Bounds provide actionable answers:
   they tell practitioners which values are plausible,
   enabling informed decisions without arbitrary significance thresholds.
 
-Traditional Mann-Whitney implementations apply tie correction when samples contain repeated values.
+Traditional Mann--Whitney implementations apply tie correction when samples contain repeated values.
 This correction modifies variance calculations to account for tied observations,
   changing $p$-values and confidence intervals in ways that depend on measurement precision.
 The toolkit deliberately omits tie correction.

--- a/manual/pairwise-margin/pairwise-margin.typ
+++ b/manual/pairwise-margin/pairwise-margin.typ
@@ -11,7 +11,7 @@ Exclusion count for dominance-based bounds.
 
 #list(marker: none, tight: true,
   [$n, m >= 1$ — sample sizes],
-  [$misrate > 2 / binom(n+m, n)$ — error rate (minimum achievable)],
+  [$misrate >= 2 / binom(n+m, n)$ — error rate (minimum achievable)],
 )
 
 #v(0.3em)

--- a/manual/ratio-bounds/ratio-bounds.typ
+++ b/manual/ratio-bounds/ratio-bounds.typ
@@ -28,7 +28,7 @@ Robust bounds on #link(<sec-ratio>)[$Ratio(vx, vy)$] with specified coverage —
 
 #list(marker: none, tight: true,
   [*Also known as* — distribution-free confidence interval for Hodges-Lehmann ratio],
-  [*Note* — assumes weak continuity (ties from measurement resolution are tolerated but may yield conservative bounds)],
+  [*Note* — assumes #link(<sec-weak-shape>)[weak shape] in log-space and weak continuity (ties from measurement resolution are tolerated but may yield conservative bounds)],
 )
 
 #v(0.5em)
@@ -60,7 +60,10 @@ $RatioBounds$ returns $[e^a, e^b]$.
 $RatioBounds$ provides not just the estimated ratio but also the uncertainty of that estimate.
 The function returns an interval of plausible ratio values given the data.
 Set $misrate$ to control how often the bounds might fail to contain the true ratio: use $10^(-3)$ for everyday analysis or $10^(-6)$ for critical decisions where errors are costly.
-These bounds require no assumptions about your data distribution, so they remain valid for any continuous positive measurements.
+These bounds require #link(<sec-weak-shape>)[weak shape] but no specific distributional form:
+  coverage is exact for any continuous positive distributions that differ only by scale,
+  so that the log-transformed samples differ only by a shift.
+When the shapes differ, the actual coverage may deviate from $1 - misrate$.
 If the bounds exclude $1$, that suggests a reliable multiplicative difference between the two groups.
 
 #v(0.5em)

--- a/manual/ratio-bounds/ratio-bounds.typ
+++ b/manual/ratio-bounds/ratio-bounds.typ
@@ -27,7 +27,7 @@ Robust bounds on #link(<sec-ratio>)[$Ratio(vx, vy)$] with specified coverage —
 *Notes*
 
 #list(marker: none, tight: true,
-  [*Also known as* — distribution-free confidence interval for Hodges-Lehmann ratio],
+  [*Also known as* — distribution-free confidence interval for Hodges--Lehmann ratio],
   [*Note* — assumes #link(<sec-weak-shape>)[weak shape] in log-space and weak continuity (ties from measurement resolution are tolerated but may yield conservative bounds)],
 )
 

--- a/manual/ratio/ratio-algorithm.typ
+++ b/manual/ratio/ratio-algorithm.typ
@@ -14,7 +14,7 @@ Taking the logarithm of a ratio yields a difference:
 
 $ log(x_i / y_j) = log(x_i) - log(y_j) $
 
-This transforms the problem of finding the median of pairwise ratios
+This turns the multiplicative aggregation
 into finding the median of pairwise differences in log-space.
 
 The algorithm operates in three steps:
@@ -27,7 +27,8 @@ The algorithm operates in three steps:
   This leverages the $O((m + n) log L)$ complexity of the Shift algorithm.
 
 + *Exp-transform* — Apply $exp$ to convert the result back to ratio-space.
-  If the log-space median is $d$, then $exp(d) = exp(log(x_i) - log(y_j)) = x_i / y_j$ is the original ratio.
+  Since $exp(log(x_i) - log(y_j)) = x_i \/ y_j$, exponentiating the log-space median
+  returns the estimate on the original ratio scale.
 
 The total complexity is $O((m + n) log L)$ per quantile,
 where $L$ represents the convergence precision in the log-space binary search.

--- a/manual/ratio/ratio.typ
+++ b/manual/ratio/ratio.typ
@@ -18,7 +18,7 @@ Robust measure of scale ratio between two samples — the multiplicative dual of
 *Output*
 
 #list(marker: none, tight: true,
-  [*Value* — estimation of the geometric median of pairwise ratios $x_i / y_j$ (via log-space aggregation)],
+  [*Value* — estimation of the median of pairwise log-ratios $log(x_i \/ y_j)$, exponentiated],
   [*Unit* — dimensionless],
 )
 
@@ -49,7 +49,7 @@ Robust measure of scale ratio between two samples — the multiplicative dual of
 
 $Ratio$ is the multiplicative analog of #link(<sec-shift>)[$Shift$].
 While #link(<sec-shift>)[$Shift$] computes the median of pairwise differences $x_i - y_j$,
-$Ratio$ computes the median of pairwise ratios $x_i / y_j$ via log-transformation.
+$Ratio$ computes the median of pairwise log-ratios $log(x_i \/ y_j)$ and exponentiates the result.
 This relationship is expressed formally as:
 
 $ Ratio(vx, vy) = exp(Shift(log vx, log vy)) $

--- a/manual/shift-bounds/shift-bounds.typ
+++ b/manual/shift-bounds/shift-bounds.typ
@@ -31,7 +31,7 @@ Robust bounds on #link(<sec-shift>)[$Shift(vx, vy)$] with specified coverage.
 *Notes*
 
 #list(marker: none, tight: true,
-  [*Also known as* — distribution-free confidence interval for Hodges-Lehmann],
+  [*Also known as* — distribution-free confidence interval for Hodges--Lehmann],
   [*Note* — assumes #link(<sec-weak-shape>)[weak shape] and weak continuity (ties from measurement resolution are tolerated but may yield conservative bounds)],
 )
 

--- a/manual/shift-bounds/shift-bounds.typ
+++ b/manual/shift-bounds/shift-bounds.typ
@@ -32,7 +32,7 @@ Robust bounds on #link(<sec-shift>)[$Shift(vx, vy)$] with specified coverage.
 
 #list(marker: none, tight: true,
   [*Also known as* — distribution-free confidence interval for Hodges-Lehmann],
-  [*Note* — assumes weak continuity (ties from measurement resolution are tolerated but may yield conservative bounds)],
+  [*Note* — assumes #link(<sec-weak-shape>)[weak shape] and weak continuity (ties from measurement resolution are tolerated but may yield conservative bounds)],
 )
 
 #v(0.5em)
@@ -53,7 +53,9 @@ Robust bounds on #link(<sec-shift>)[$Shift(vx, vy)$] with specified coverage.
 $ShiftBounds$ provides not just the estimated shift but also the uncertainty of that estimate.
 The function returns an interval of plausible shift values given the data.
 Set $misrate$ to control how often the bounds might fail to contain the true shift: use $10^(-3)$ for everyday analysis or $10^(-6)$ for critical decisions where errors are costly.
-These bounds require no assumptions about your data distribution, so they remain valid for any continuous measurements.
+These bounds require #link(<sec-weak-shape>)[weak shape] but no specific distributional form:
+  coverage is exact for any continuous distributions that differ only by a shift.
+When the shapes differ, the actual coverage may deviate from $1 - misrate$.
 If the bounds exclude zero, that suggests a reliable difference between the two groups.
 
 #v(0.5em)

--- a/manual/shift/shift.typ
+++ b/manual/shift/shift.typ
@@ -26,7 +26,7 @@ Robust measure of location difference between two samples.
 *Notes*
 
 #list(marker: none, tight: true,
-  [*Also known as* — Hodges-Lehmann estimator for two samples],
+  [*Also known as* — Hodges--Lehmann estimator for two samples],
   [*Complexity* — $O((m+n) log L)$],
 )
 

--- a/manual/shuffle/shuffle-algorithm.typ
+++ b/manual/shuffle/shuffle-algorithm.typ
@@ -1,6 +1,6 @@
 #import "/manual/definitions.typ": *
 
-The $Shuffle$ function uses the Fisher-Yates algorithm (see @fisher1938, @knuth1997),
+The $Shuffle$ function uses the Fisher--Yates algorithm (see @fisher1938, @knuth1997),
   also known as the Knuth shuffle,
   with the #link(<sec-rng>)[Rng] generator for random decisions:
 

--- a/manual/shuffle/shuffle.typ
+++ b/manual/shuffle/shuffle.typ
@@ -8,7 +8,7 @@ Uniformly random permutation of sample $vx$ using generator $r$.
 
 #v(0.3em)
 #list(marker: none, tight: true,
-  [*Algorithm* — Fisher-Yates (Knuth shuffle), see #link(<sec-alg-shuffle>)[Shuffle]],
+  [*Algorithm* — Fisher--Yates (Knuth shuffle), see #link(<sec-alg-shuffle>)[Shuffle]],
   [*Complexity* — $O(n)$ time, $O(n)$ space (returns new array)],
   [*Output* — new array (does not modify input)],
 )

--- a/manual/sign-margin/sign-margin-algorithm.typ
+++ b/manual/sign-margin/sign-margin-algorithm.typ
@@ -9,8 +9,11 @@ Given $n$ pairs and a desired $misrate$, the algorithm finds
 
 *Binomial CDF computation*
 
-Under the symmetry assumption, the number of positive signs among $n$ disjoint-pair differences
-  follows $"Binomial"(n, 1\/2)$.
+Each disjoint-pair value exceeds the true parameter with probability $1\/2$ by construction,
+  since that parameter is the median of the distribution those values are drawn from
+  (for #link(<sec-spread-bounds>)[$SpreadBounds$], the absolute differences $abs(X_1 - X_2)$).
+The count of values above the parameter therefore follows $"Binomial"(n, 1\/2)$;
+  no symmetry assumption is needed.
 The CDF is computed exactly:
 
 $ Pr(W <= k) = sum_(i=0)^k binom(n, i) 2^(-n) $
@@ -23,7 +26,7 @@ The algorithm evaluates this sum incrementally,
 Because the Binomial CDF is a step function, the exact $misrate$ typically falls between
   two adjacent grid points $k$ and $k + 1$.
 The algorithm identifies these adjacent values:
-$k_"lo"$ is the largest integer where $Pr(W <= k_"lo") < misrate / 2$
+$k_"lo"$ is the largest integer where $Pr(W <= k_"lo") <= misrate / 2$
 and $k_"hi" = k_"lo" + 1$.
 
 *Randomized cutoff*
@@ -31,7 +34,7 @@ and $k_"hi" = k_"lo" + 1$.
 To match the requested $misrate$ exactly rather than conservatively,
   the algorithm interpolates between the two grid points.
 It computes a probability $p$ such that
-  using margin $2 k_"lo"$ with probability $p$ and margin $2 k_"hi"$ with probability $1 - p$
+  using margin $2 k_"hi"$ with probability $p$ and margin $2 k_"lo"$ with probability $1 - p$
   yields an expected coverage of exactly $1 - misrate$.
 A uniform random draw determines which margin to return.
 

--- a/manual/signed-rank-margin/signed-rank-margin-algorithm.typ
+++ b/manual/signed-rank-margin/signed-rank-margin-algorithm.typ
@@ -10,7 +10,7 @@ The challenge lies in determining which order statistics produce bounds
   that contain the true center with probability $1 - misrate$.
 
 The margin function is the one-sample analog of $PairwiseMargin$.
-While $PairwiseMargin$ uses the Mann-Whitney distribution for two-sample comparisons,
+While $PairwiseMargin$ uses the Mann--Whitney distribution for two-sample comparisons,
   $SignedRankMargin$ uses the Wilcoxon signed-rank distribution for one-sample inference.
 Under the weak symmetry assumption, the signed-rank statistic has a known distribution
   that enables exact computation of bounds coverage.

--- a/manual/signed-rank-margin/signed-rank-margin-algorithm.typ
+++ b/manual/signed-rank-margin/signed-rank-margin-algorithm.typ
@@ -125,8 +125,8 @@ The table below shows $misrate_min$ for small sample sizes:
   table.hline(),
 )
 
-For meaningful bounds construction, choose $misrate > misrate_min$.
-With $n >= 10$, standard choices like $misrate = 10^(-3)$ become feasible.
-With $n >= 20$, even $misrate = 10^(-6)$ is achievable.
+For meaningful bounds construction, choose $misrate >= misrate_min$.
+With $n >= 11$, standard choices like $misrate = 10^(-3)$ become feasible.
+With $n >= 21$, even $misrate = 10^(-6)$ is achievable.
 
 #source-include("cs/Pragmastat/Functions/SignedRankMargin.cs", "cs")

--- a/manual/spread-bounds/spread-bounds-algorithm.typ
+++ b/manual/spread-bounds/spread-bounds-algorithm.typ
@@ -12,7 +12,7 @@ Given a sample $vx = (x_1, ..., x_n)$, the algorithm proceeds as follows:
 
 + *Absolute differences* ---
   For each pair $(x_(a_i), x_(b_i))$, compute the absolute difference $d_i = abs(x_(a_i) - x_(b_i))$.
-  Under the sparity assumption, these $m$ absolute differences are exchangeable.
+  Since the pairs are disjoint, these $m$ absolute differences are independent and identically distributed.
 
 + *Sort* ---
   Sort the differences to obtain $d_((1)) <= d_((2)) <= ... <= d_((m))$.
@@ -25,9 +25,11 @@ Given a sample $vx = (x_1, ..., x_n)$, the algorithm proceeds as follows:
   Return $[d_((k_L)), d_((k_U))]$ where $k_L = floor(r / 2) + 1$ and $k_U = m - floor(r / 2)$.
   Clamping ensures the indices remain within $[1, m]$.
 
-The key insight is that disjoint pairs provide independence under the symmetry assumption.
-Under weak symmetry around the true spread, each absolute difference is equally likely
-  to exceed or fall below the population spread.
+The key insight is that disjoint pairs provide independence:
+  since the pairs share no observations, the $m$ absolute differences are i.i.d.
+Each difference is equally likely to exceed or fall below the population spread
+  because that spread is by definition the median of $abs(X_1 - X_2)$;
+  no symmetry assumption is needed.
 This makes the count of differences exceeding the spread a $"Binomial"(m, 1\/2)$ variable,
   enabling exact coverage control via the sign test.
 

--- a/manual/spread/spread-notes.typ
+++ b/manual/spread/spread-notes.typ
@@ -42,7 +42,8 @@ The $Spread$ estimator achieves a $29%$ breakdown point,
 ==== Drift
 
 Drift measures estimator precision by quantifying how much estimates scatter across repeated samples.
-It is based on the $Spread$ of estimates and therefore has a breakdown point of approximately $29%$.
+It is based on the $Spread$ of estimates, so its empirical evaluation across repeated samples
+  inherits the $29%$ breakdown point of $Spread$.
 
 Drift is useful for comparing the precision of several estimators.
 To simplify the comparison, one of the estimators can be chosen as a baseline.

--- a/manual/synopsis/synopsis.typ
+++ b/manual/synopsis/synopsis.typ
@@ -90,9 +90,9 @@ The table below maps each toolkit function to the underlying algorithm and its c
   table.hline(),
   [$UniformFloat$], [53-bit extraction from xoshiro256++ output], [$O(1)$ per draw],
   [$UniformInt$], [Modulo reduction of raw 64-bit output], [$O(1)$ per draw],
-  [$Sample$], [Fan-Muller-Rezucha selection sampling], [$O(n)$],
+  [$Sample$], [Fan--Muller--Rezucha selection sampling], [$O(n)$],
   [$Resample$], [Uniform integer sampling with replacement], [$O(k)$],
-  [$Shuffle$], [Fisher-Yates (Knuth shuffle)], [$O(n)$],
+  [$Shuffle$], [Fisher--Yates (Knuth shuffle)], [$O(n)$],
   table.hline(),
 )
 

--- a/tools/src/xref.rs
+++ b/tools/src/xref.rs
@@ -34,6 +34,10 @@ impl XRefMap {
             "sec-weak-symmetry".into(),
             "/assumptions#weak-symmetry-assumption".into(),
         );
+        mappings.insert(
+            "sec-weak-shape".into(),
+            "/assumptions#weak-shape-assumption".into(),
+        );
 
         // Test framework -> methodology
         mappings.insert(
@@ -201,6 +205,15 @@ mod tests {
         assert_eq!(
             xref.resolve("sec-test-framework"),
             Some("/methodology#test-framework")
+        );
+    }
+
+    #[test]
+    fn resolve_weak_shape_label() {
+        let xref = XRefMap::new();
+        assert_eq!(
+            xref.resolve("sec-weak-shape"),
+            Some("/assumptions#weak-shape-assumption")
         );
     }
 


### PR DESCRIPTION
Five corrections to statements in the manual that were wrong rather than merely unclear: the minimum achievable misrate thresholds were off by one sample (1e-6 needs n >= 21, not 20; 1e-3 needs n >= 11, not 10, contradicting both the adjacent table and the methodology chapter), SignMargin described its randomized cutoff backwards relative to the implementation, SpreadBounds justified independence by "the sparity assumption" (which means `Spread(x) > 0` and is unrelated) and by a symmetry it does not need, Ratio was defined as a "geometric median of pairwise ratios" which is neither the term's meaning nor what the code computes, and ShiftBounds/RatioBounds promised coverage that "requires no assumptions about your data distribution" when exact coverage in fact needs a location-shift model. The last one gets a new Weak Shape Assumption section next to Weak Symmetry, referenced from the three functions that depend on it.

## Appendix

Stacked on #75, which fixes the generator bugs this work uncovered; the `sec-weak-shape` xref entry lives here because the label it points at is added here.

Verified numerically where numbers were involved: 2^-19 = 1.907e-6 > 1e-6 while 2^-20 = 9.537e-7 <= 1e-6; the 86% figure for Spread follows from the drift table in the Additive chapter (0.45/0.52) and matches the classical 0.8637 for the Shamos estimator; the randomized cutoff satisfies CDF(k_lo) + p*PMF(k_lo+1) = misrate/2, which holds only with 2*k_hi taken at probability p.

The shift model is written as F_X(t) = F_Y(t - delta), giving X = Y + delta in distribution. The opposite orientation makes Shift(x, y) estimate -delta.

The last commit is a separate concern: compound proper names now use an en dash throughout. Fisher-Yates was spelled two different ways, which only became visible once the generator stopped discarding dash shorthands.

`docs:ci` passes, as do `cs`, `go`, `kt`, `rs`, `ts` and `r`. `py:check` fails locally because a pip-installed ruff shadows the pinned one; unrelated, and described in #75.