### PR TITLE
Keep @types/node aligned with the pinned Node runtime

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -69,6 +69,12 @@ updates:
       - dependency-name: "katex"
         update-types:
           ["version-update:semver-minor", "version-update:semver-major"]
+      # @types/node describes the runtime, so its major must track the Node
+      # version the project actually runs: mise pins node 22 and ts/package.json
+      # declares engines >=22. Newer types would type-check calls that the
+      # pinned runtime does not have. Bump this together with the runtime.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: pip
     directories:


### PR DESCRIPTION
`@types/node` describes the runtime API surface, so its major has to track the Node version the project actually runs: `mise.toml` pins node 22 and `ts/package.json` declares `engines: >=22`. #79 proposed types for Node 26, which would type-check calls the pinned runtime does not provide — the suite passes, but only because the library touches almost no Node API. Ignoring the major keeps the two in step, the same way `junit-jupiter` is already held back for the JDK pin.

## Appendix

The TypeScript library uses `fs` and `path` in one test file for reading reference data, and nothing else runtime-specific. So the risk today is small; the point is that nothing would catch it if that changed.

Bump this together with the runtime whenever node moves off 22.