### PR TITLE
Ship only the woff2 KaTeX fonts

### DIFF
--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -4,6 +4,7 @@ import mdx from '@astrojs/mdx';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import rehypeThemedImages from './src/plugins/rehype-themed-images.js';
+import katexWoff2Only from './src/plugins/vite-katex-woff2-only.js';
 import fs from 'fs';
 
 // Load KaTeX macros from generated file
@@ -37,6 +38,7 @@ export default defineConfig({
     },
   },
   vite: {
+    plugins: [katexWoff2Only()],
     server: {
       // Local dev preview over mDNS: allow any *.local host.
       allowedHosts: ['.local'],

--- a/web/src/plugins/vite-katex-woff2-only.js
+++ b/web/src/plugins/vite-katex-woff2-only.js
@@ -1,0 +1,34 @@
+/**
+ * Strip the woff and truetype fallbacks from KaTeX's @font-face rules.
+ *
+ * katex.min.css lists three formats per face:
+ *
+ *   src: url(fonts/X.woff2) format("woff2"),
+ *        url(fonts/X.woff)  format("woff"),
+ *        url(fonts/X.ttf)   format("truetype")
+ *
+ * Vite resolves every url() it finds, so all three land in the bundle: 19 woff2
+ * plus 20 woff plus 20 ttf, around 1MB, of which only the woff2 files are ever
+ * requested by a browser that supports woff2 — which every current one does.
+ * Removing the fallback urls before Vite parses the stylesheet keeps those files
+ * out of the build entirely.
+ *
+ * Runs with enforce: 'pre' so it sees the raw stylesheet, ahead of Vite's own
+ * asset resolution.
+ */
+export default function katexWoff2Only() {
+  return {
+    name: 'katex-woff2-only',
+    enforce: 'pre',
+    transform(code, id) {
+      if (!id.includes('katex') || !id.includes('.css')) return null;
+
+      const stripped = code
+        .replace(/,\s*url\([^)]+\.woff\)\s*format\("woff"\)/g, '')
+        .replace(/,\s*url\([^)]+\.ttf\)\s*format\("truetype"\)/g, '');
+
+      if (stripped === code) return null;
+      return { code: stripped, map: null };
+    },
+  };
+}


### PR DESCRIPTION
`katex.min.css` declares three formats per `@font-face` — woff2, woff and truetype — and Vite resolves every `url()` it finds, so all of them ended up in the bundle: 19 woff2 plus 20 woff plus 20 ttf. Only the woff2 files are ever fetched, since every browser in use supports woff2. A small Vite plugin strips the fallback urls before Vite parses the stylesheet, so those files are never emitted at all. Asset output drops from 1144032 to 324718 bytes — a 72% cut — with all 44 pages rendering pixel-identical.

## Appendix

The plugin runs with `enforce: 'pre'` so it sees the raw stylesheet ahead of Vite's asset resolution, and it no-ops if the pattern ever stops matching, which makes a future katex reformat visible as restored file counts rather than a silent breakage.

Verified that the fonts still load rather than silently falling back to a system face: the build emits 19 woff2, the browser fetches them with 200s and no 404s, and the pixel diff against `main` is zero on every page — a missing font would have changed the rendering immediately.

This drops support for browsers without woff2, which in practice means IE11 and pre-2016 Safari.