### PR TITLE
Align the go directive with the pinned toolchain

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,3 +1,3 @@
 module github.com/AndreyAkinshin/pragmastat/go/v14
 
-go 1.25
+go 1.26

--- a/mise.toml
+++ b/mise.toml
@@ -9,7 +9,7 @@
 # both sides in step when bumping.
 [tools]
 dotnet = "10.0"        # sync: actions/setup-dotnet in the workflows
-go = "1.26"
+go = "1.26"            # sync: the go directive in go/go.mod
 golangci-lint = "2.12.2"
 java = "temurin-21"    # sync: actions/setup-java (Gradle 9 daemon JDK; jvmToolchain still targets 11)
 node = "22"            # sync: actions/setup-node in ci.yml (publish-npm pins 24 for npm OIDC)


### PR DESCRIPTION
`go/go.mod` declared `go 1.25` while `mise.toml` pins `go = "1.26"`, so the module advertised support for a version nothing ever built or tested it with: CI provisions Go through mise, which means every test run has used 1.26. Raises the directive to 1.26 so the declared floor is the version actually exercised, and notes the pairing next to the mise pin.

## Appendix

This matches how the other languages are already set up, where the declared floor and the development version agree — `requires-python >=3.12` with `python 3.12`, `engines: node >=22` with `node 22`. Kotlin is the deliberate exception (`jvmToolchain(11)` under JDK 21) and carries a comment explaining why; Go had no such note, which is what marked it as an oversight rather than a decision.

Consumers on an older Go are unaffected in practice. Since Go 1.21 the directive is a toolchain requirement, not a hard gate: with the default `GOTOOLCHAIN=auto` it causes the newer toolchain to be fetched rather than the build to be refused.

`go:ci` and `docs:ci` pass.