### PR TITLE
Stop shadowing the pinned ruff with a pip copy

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -279,8 +279,11 @@ find . -type f -name "*.pyo" -delete 2>/dev/null || true
 description = "Install Python package and dev dependencies"
 dir = "py"
 run = """
+# ruff deliberately absent: it is a mise-managed tool pinned in [tools], and a
+# pip copy here lands in the python prefix and wins on PATH, silently replacing
+# the pinned version with whatever pip resolves.
 python -m pip install --upgrade pip
-pip install pytest build twine ruff
+pip install pytest build twine
 pip install -e .
 """
 


### PR DESCRIPTION
`py:restore` pip-installed `ruff` alongside pytest, build and twine. That copy lands in the mise python prefix, which wins on `PATH` — even mise's own shim resolved to it — so the version pinned in `[tools]` was silently replaced by whatever pip picked. Locally that meant ruff 0.15.20 instead of the pinned 0.16.0, and `py:check` failed on three `noqa: PLR0917` directives referencing a rule the older version does not know. GitHub CI happened to order `PATH` the other way, which is why it stayed green and the split went unnoticed for as long as it did.

## Appendix

Same shape as the katex and typst problems fixed earlier in this series: one tool's version declared in two places, with nothing keeping them in step. Here the second declaration was not even visible as a version — just the word `ruff` in a pip list.

After the change `mise which ruff` resolves to `installs/ruff/0.16.0/...` and stays there across a full `py:ci`, so `py:restore` no longer reintroduces the shadow. `py/` is clean under the pinned version: all checks pass, 39 files already formatted, 119 tests green, both wheel and sdist pass `twine check`.

With this, a full `mise run ci` — all eight languages plus docs — passes locally for the first time; previously it always stopped at `py:check`.