### PR TITLE
Run the documentation pipeline through docs:ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,43 +39,26 @@ jobs:
     # --- Rust tools (for Typst → MDX conversion) ---
     - name: Set up Rust
       uses: dtolnay/rust-toolchain@1.97.1  # sync: [tools].rust in mise.toml
+      with:
+        components: rustfmt, clippy  # docs:ci runs tools:check
 
     - name: Cache Rust tools
       uses: Swatinem/rust-cache@v2
       with:
         workspaces: "tools -> target"
 
-    # --- Image generation ---
+    # --- Python for figure generation (img:build manages its own venv) ---
     - name: Set up Python
       uses: actions/setup-python@v7
       with:
         python-version: '3.12'  # keep in sync with [tools].python in mise.toml
 
-    - name: Install image dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-      working-directory: img
-
-    - name: Generate images
-      run: mise run img:build
-
-    # --- PDF generation ---
-    - name: Install Typst
-      uses: typst-community/setup-typst@v5
-
-    - name: Download fonts
-      run: mise run pdf:restore
-
-    - name: Build PDF
-      run: mise run pdf:build
-
-    # --- Web build ---
-    - name: Install web dependencies
-      run: mise run web:restore
-
-    - name: Build website
-      run: mise run web:build${{ inputs.release && ':release' || '' }}
+    # Runs the same pipeline as local development, so the Clippy, rustfmt, test
+    # and generated-docs-drift gates in docs:ci apply here too. Typst comes from
+    # mise at the version pinned in [tools]; figures, fonts and web dependencies
+    # are pulled in through the task's own dependencies.
+    - name: Build documentation
+      run: mise run docs:ci${{ inputs.release && ':release' || '' }}
 
     - name: Copy PDF to web output
       run: cp manual/pragmastat.pdf web/dist/

--- a/manual/pairwise-margin/pairwise-margin-algorithm.typ
+++ b/manual/pairwise-margin/pairwise-margin-algorithm.typ
@@ -250,9 +250,10 @@ The table below shows $misrate_min$ for small sample sizes:
   table.hline(),
 )
 
-For meaningful bounds construction, choose $misrate >= misrate_min$.
-This ensures the margin function excludes at least some extreme pairwise differences,
-  producing bounds narrower than the full range.
+The accepted domain is $misrate >= misrate_min$.
+At exact equality the margin is $0$, so the bounds span the full range of pairwise
+  differences: admissible, but carrying no information.
+For bounds narrower than that range, choose $misrate > misrate_min$.
 When working with small samples, verify that the desired misrate exceeds $misrate_min$
   for the given sample sizes.
 With moderate sample sizes ($n, m >= 15$), $misrate_min$ drops below $10^(-8)$,

--- a/manual/signed-rank-margin/signed-rank-margin-algorithm.typ
+++ b/manual/signed-rank-margin/signed-rank-margin-algorithm.typ
@@ -125,7 +125,9 @@ The table below shows $misrate_min$ for small sample sizes:
   table.hline(),
 )
 
-For meaningful bounds construction, choose $misrate >= misrate_min$.
+The accepted domain is $misrate >= misrate_min$, but equality yields a margin of $0$,
+  leaving the bounds at the full range of pairwise averages.
+For informative bounds, choose $misrate > misrate_min$.
 With $n >= 11$, standard choices like $misrate = 10^(-3)$ become feasible.
 With $n >= 21$, even $misrate = 10^(-6)$ is achievable.
 

--- a/mise.toml
+++ b/mise.toml
@@ -772,6 +772,18 @@ run = [
     { task = "web:build" },
 ]
 
+[tasks."docs:ci:release"]
+description = "Run documentation CI pipeline (release mode)"
+run = [
+    { task = "tools:check" },
+    { task = "tools:test" },
+    { task = "docs:clean" },
+    { task = "docs:sync" },
+    "git diff --exit-code || { echo 'ERROR: docs:sync produced uncommitted drift — regenerate and commit generated docs' >&2; exit 1; }",
+    { task = "pdf:build:release" },
+    { task = "web:build:release" },
+]
+
 # ==========================================================================
 # Aggregate Tasks
 # ==========================================================================


### PR DESCRIPTION
Three review follow-ups. `ci-manual` invoked `img:build`, `pdf:build` and `web:build` one by one and never called `docs:ci`, so the Clippy, rustfmt, 125-test and generated-docs-drift gates added alongside the tools tasks ran only on a developer machine — a parser or XRef regression would not have blocked a release. The job now runs `docs:ci` (with a `docs:ci:release` variant for the release path), which also removes `typst-community/setup-typst`: it was called without a version, resolved to `latest`, and silently bypassed the 0.15.1 pin that has to stay in lockstep with `tools`' `typst-syntax`. And the misrate wording promised more than the code delivers at exact equality.

## Appendix

The figure, font and web-dependency steps drop out of the workflow because `pdf:build` and `web:build` already declare them as dependencies — the workflow was restating what the task graph knows. `pdf:build:release` is identical to `pdf:build`, and `web:build:release` differs only by `NODE_ENV=production`, so the release variant is a thin wrapper.

`typst-version: latest` was visible verbatim in the run log, which is what made this concrete rather than theoretical. typst now comes from mise alone, at the pinned version.

On the misrate text: the domain genuinely accepts `misrate == misrate_min` — the code rejects only `misrate < minMisrate`, so the earlier `>=` correction stands. But at exact equality both margin functions return 0 and the bounds span the full range. Verified numerically: for n=m=5 the CDF starts at `1/C(n+m,n)`, which equals `misrate_min/2`, so `cdf >= p` passes on the first comparison; `SignedRankMargin` behaves the same at `2^(1-n)`. The two statements — what is admissible, and what yields informative bounds — are now separate sentences.

`docs:ci` passes locally including the drift check.