### PR TITLE
Propagate NaN, and finish the signed-zero work in Go

### DIFF
--- a/cs/AGENTS.md
+++ b/cs/AGENTS.md
@@ -35,6 +35,8 @@ cs/
 │   ├── Functions/
 │   │   ├── PairwiseMargin.cs
 │   │   ├── ErrorFunction.cs
+│   │   ├── AdditiveCumulative.cs         # Standard normal CDF (Chebyshev-fitted erf/erfc)
+│   │   ├── ExpFunction.cs         # Reproducible exp: range reduction plus fitted polynomial
 │   │   └── ...
 │   ├── Bounds.cs               # Lower/upper bound pair
 │   ├── Probability.cs          # Probability value type

--- a/cs/Pragmastat.TestGenerator/Program.cs
+++ b/cs/Pragmastat.TestGenerator/Program.cs
@@ -19,7 +19,7 @@ string[] ownedSharedSuites =
   "shift", "shift-bounds", "ratio", "ratio-bounds",
   "disparity", "disparity-bounds", "avg-spread", "avg-spread-bounds",
   "compare1", "compare2", "pairwise-margin", "signed-rank-margin",
-  "portable-exp",
+  "exp-function",
 ];
 
 foreach (string suite in ownedSharedSuites)
@@ -46,7 +46,7 @@ OneSampleTestCases.Generate();
 TwoSampleTestCases.Generate();
 DistributionTestCases.Generate();
 ApproximationTestCases.Generate();
-PortableExpTestCases.Generate();
+ExpFunctionTestCases.Generate();
 PairwiseMarginTestCases.Generate();
 ShiftBoundsTestCases.Generate();
 RatioBoundsTestCases.Generate();

--- a/cs/Pragmastat.TestGenerator/TestCases/ApproximationTestCases.cs
+++ b/cs/Pragmastat.TestGenerator/TestCases/ApproximationTestCases.cs
@@ -20,8 +20,8 @@ public static class ApproximationTestCases
     double[] milliles = Uniform(0, 1, 1001, 1);
     double[] normalMilliles = milliles.Select(p => ((IContinuousDistribution)Additive.Standard).Quantile(p)).ToArray();
 
-    functions["gauss_cdf"] = GaussCdf.Value;
-    inputBuilder.Add("gauss_cdf", new SingleDoubleValueInput("gauss_cdf", normalMilliles));
+    functions["additive_cumulative"] = AdditiveCumulative.Value;
+    inputBuilder.Add("additive_cumulative", new SingleDoubleValueInput("additive_cumulative", normalMilliles));
 
     functions["erf"] = AbramowitzStegunErf.Value;
     inputBuilder.Add("erf", new SingleDoubleValueInput("erf", normalMilliles));

--- a/cs/Pragmastat.TestGenerator/TestCases/ExpFunctionTestCases.cs
+++ b/cs/Pragmastat.TestGenerator/TestCases/ExpFunctionTestCases.cs
@@ -28,19 +28,19 @@ namespace Pragmastat.TestGenerator.TestCases;
 /// them either.
 /// </para>
 /// </remarks>
-public static class PortableExpTestCases
+public static class ExpFunctionTestCases
 {
   public static void Generate()
   {
-    const string suiteName = "portable-exp";
+    const string suiteName = "exp-function";
     AnsiConsole.MarkupLine($"[yellow]→[/] Generating tests for: [bold]{suiteName}[/]");
 
-    var functions = new Dictionary<string, Func<double, double>> { ["portable_exp"] = PortableExp.Value };
+    var functions = new Dictionary<string, Func<double, double>> { ["exp_function"] = ExpFunction.Value };
     var inputBuilder = new ReferenceTestCaseInputBuilder<SingleDoubleValueInput>();
 
-    inputBuilder.Add("working-band", new SingleDoubleValueInput("portable_exp", Grid(-18.5, 0.0, 401)));
-    inputBuilder.Add("edgeworth-band", new SingleDoubleValueInput("portable_exp", Grid(-40.0, 0.0, 201)));
-    inputBuilder.Add("finite-range", new SingleDoubleValueInput("portable_exp", Grid(-745.0, 709.0, 401)));
+    inputBuilder.Add("working-band", new SingleDoubleValueInput("exp_function", Grid(-18.5, 0.0, 401)));
+    inputBuilder.Add("edgeworth-band", new SingleDoubleValueInput("exp_function", Grid(-40.0, 0.0, 201)));
+    inputBuilder.Add("finite-range", new SingleDoubleValueInput("exp_function", Grid(-745.0, 709.0, 401)));
 
     // The reduction endpoints, the underflow cutoff and its neighbors, and the first denormals:
     // every place the construction changes behavior rather than merely continues.
@@ -49,7 +49,7 @@ public static class PortableExpTestCases
     // write one. The overflow cutoff is checked in each port's own unit tests, where a language
     // can name its infinity; everything JSON can carry is here.
     const double ln2 = 0.69314718055994531;
-    inputBuilder.Add("boundaries", new SingleDoubleValueInput("portable_exp",
+    inputBuilder.Add("boundaries", new SingleDoubleValueInput("exp_function",
     [
       0.0, -0.0, 1.0, -1.0, 0.5, -0.5, 100.0, -100.0,
       ln2, -ln2, ln2 / 2, -ln2 / 2, 3 * ln2 / 2, -3 * ln2 / 2,

--- a/cs/Pragmastat.Tests/ApproximationTests.cs
+++ b/cs/Pragmastat.Tests/ApproximationTests.cs
@@ -13,7 +13,7 @@ public class ApproximationTests
   {
     var functions = new Dictionary<string, Func<double, double>>
     {
-      ["gauss_cdf"] = GaussCdf.Value,
+      ["additive_cumulative"] = AdditiveCumulative.Value,
       ["erf"] = AbramowitzStegunErf.Value,
       ["erf_inverse"] = ErfInverse.Value
     };

--- a/cs/Pragmastat.Tests/Functions/ExpFunctionTests.cs
+++ b/cs/Pragmastat.Tests/Functions/ExpFunctionTests.cs
@@ -75,4 +75,35 @@ public class ExpFunctionTests
     Assert.Equal(FixtureFileCount, testNames.Length);
     Assert.Equal(FixtureArgumentCount, testNames.Sum(name => controller.LoadTestCase(name).Input.Arg.Length));
   }
+
+  /// <summary>
+  /// Both of AdditiveCumulative's range comparisons are false for a NaN, so without an explicit guard it
+  /// leaves the tail branch as a finite 0 or 1: an undefined input answered rather than reported.
+  /// The approximation it replaced propagated NaN, so losing that would be a regression.
+  /// </summary>
+  [Fact]
+  public void AdditiveCumulativeCarriesNaNThroughAndAnswersBothInfinities()
+  {
+    Assert.True(double.IsNaN(AdditiveCumulative.Value(double.NaN)));
+    BitwiseAssert.Equal(1.0, AdditiveCumulative.Value(double.PositiveInfinity), "AdditiveCumulative(+Inf)");
+    BitwiseAssert.Equal(0.0, AdditiveCumulative.Value(double.NegativeInfinity), "AdditiveCumulative(-Inf)");
+    BitwiseAssert.Equal(0.5, AdditiveCumulative.Value(0.0), "AdditiveCumulative(+0)");
+    BitwiseAssert.Equal(0.5, AdditiveCumulative.Value(-0.0), "AdditiveCumulative(-0)");
+  }
+
+  /// <summary>
+  /// The values outside the reduction band, which the shared fixture cannot carry: JSON has no way
+  /// to express an infinity, so the generated suite stops at 709.78 and these arguments are
+  /// covered here or nowhere.
+  /// </summary>
+  [Fact]
+  public void ReturnsTheDeclaredValuesOutsideTheReductionBand()
+  {
+    Assert.True(double.IsNaN(ExpFunction.Value(double.NaN)));
+    BitwiseAssert.Equal(double.PositiveInfinity, ExpFunction.Value(709.8), "ExpFunction(709.8)");
+    BitwiseAssert.Equal(double.PositiveInfinity, ExpFunction.Value(double.PositiveInfinity), "ExpFunction(+Inf)");
+    BitwiseAssert.Equal(0.0, ExpFunction.Value(-745.3), "ExpFunction(-745.3)");
+    BitwiseAssert.Equal(0.0, ExpFunction.Value(double.NegativeInfinity), "ExpFunction(-Inf)");
+    BitwiseAssert.Equal(1.0, ExpFunction.Value(0.0), "ExpFunction(0)");
+  }
 }

--- a/cs/Pragmastat.Tests/Functions/ExpFunctionTests.cs
+++ b/cs/Pragmastat.Tests/Functions/ExpFunctionTests.cs
@@ -27,9 +27,9 @@ namespace Pragmastat.Tests.Functions;
 /// would fail here rather than pass quietly.
 /// </para>
 /// </remarks>
-public class PortableExpTests
+public class ExpFunctionTests
 {
-  private const string SuiteName = "portable-exp";
+  private const string SuiteName = "exp-function";
 
   // The size of the generated fixture: four files, 1032 arguments. Pinned rather than counted from
   // whatever the loader happened to find, because a count derived from the loader's own result
@@ -42,7 +42,7 @@ public class PortableExpTests
   // route through BitwiseAssert, which reports the divergent index and both payloads.
   private readonly SingleDoubleValueController controller = new(
     SuiteName,
-    new Dictionary<string, Func<double, double>> { ["portable_exp"] = PortableExp.Value },
+    new Dictionary<string, Func<double, double>> { ["exp_function"] = ExpFunction.Value },
     eps: 0,
     shared: true);
 
@@ -52,7 +52,7 @@ public class PortableExpTests
 
   [Theory]
   [MemberData(nameof(TestDataNames))]
-  public void PortableExpTest(string testName)
+  public void ExpFunctionTest(string testName)
   {
     var testCase = controller.LoadTestCase(testName);
     var actual = controller.Run(testCase.Input);

--- a/cs/Pragmastat/Distributions/Additive.cs
+++ b/cs/Pragmastat/Distributions/Additive.cs
@@ -84,7 +84,7 @@ public sealed class Additive : IDistribution, IContinuousDistribution
 
   double IContinuousDistribution.Cdf(double x)
   {
-    return GaussCdf.Value((x - Mean) / StdDev);
+    return AdditiveCumulative.Value((x - Mean) / StdDev);
   }
 
   double IContinuousDistribution.Quantile(Probability p)

--- a/cs/Pragmastat/Distributions/Multiplic.cs
+++ b/cs/Pragmastat/Distributions/Multiplic.cs
@@ -76,7 +76,11 @@ public sealed class Multiplic : IDistribution, IContinuousDistribution
   double IContinuousDistribution.Cdf(double x)
   {
     if (x < 1e-9) return 0;
-    return 0.5 * (1 + ErrorFunction.Value((Math.Log(x) - LogMean) / (Constants.Sqrt2 * LogStdDev)));
+    // A lognormal variable's distribution function is the normal one applied to log x, so this
+    // goes through AdditiveCumulative rather than spelling the same thing out through erf. The previous
+    // form reached AbramowitzStegunErf, accurate to 1.5e-7, which left two neighboring
+    // distributions in this library eight orders of magnitude apart for no reason.
+    return AdditiveCumulative.Value((Math.Log(x) - LogMean) / LogStdDev);
   }
 
   double IContinuousDistribution.Quantile(Probability p)

--- a/cs/Pragmastat/Functions/AdditiveCumulative.cs
+++ b/cs/Pragmastat/Functions/AdditiveCumulative.cs
@@ -8,22 +8,22 @@ namespace Pragmastat.Functions;
 /// <remarks>
 /// <para>
 /// Two Chebyshev-fitted Horner chains and one exponential. The coefficients are produced by
-/// tests/oracles/fit_gauss_cdf.py against a reference good to 36 digits, so they are
+/// tests/oracles/fit_additive_cumulative.py against a reference good to 36 digits, so they are
 /// reproducible rather than transcribed.
 /// </para>
 /// <para>
 /// Worst relative error is 9.1e-15 over |x| &lt;= 6, measured in binary64 against that reference.
 /// </para>
 /// </remarks>
-internal static class GaussCdf
+internal static class AdditiveCumulative
 {
   /// <summary>
   /// Area under the standard normal curve from negative infinity to <paramref name="x"/>.
   /// </summary>
-  /// <param name="x">-infinity..+infinity</param>
-  public static double Value(double x)
+  /// <param name="z">-infinity..+infinity</param>
+  public static double Value(double z)
   {
-    double t = Abs(x) / Constants.Sqrt2;
+    double t = Abs(z) / Constants.Sqrt2;
     if (t < 0.5)
     {
       double s = t * t;
@@ -41,7 +41,7 @@ internal static class GaussCdf
       p = p * u - 0.04364205888669792;
       p = p * u + 1.0830752376761712;
       double erf = t * p;
-      return x >= 0 ? 0.5 * (1.0 + erf) : 0.5 * (1.0 - erf);
+      return z >= 0 ? 0.5 * (1.0 + erf) : 0.5 * (1.0 - erf);
     }
 
     double erfc = 0.0;
@@ -75,9 +75,9 @@ internal static class GaussCdf
       p = p * u + 0.09925390090168178;
       p = p * u - 0.15121195850373031;
       p = p * u + 0.21849873453703333;
-      erfc = PortableExp.Value(-(t * t)) * p;
+      erfc = ExpFunction.Value(-(t * t)) * p;
     }
 
-    return x >= 0 ? 1.0 - 0.5 * erfc : 0.5 * erfc;
+    return z >= 0 ? 1.0 - 0.5 * erfc : 0.5 * erfc;
   }
 }

--- a/cs/Pragmastat/Functions/AdditiveCumulative.cs
+++ b/cs/Pragmastat/Functions/AdditiveCumulative.cs
@@ -23,6 +23,10 @@ internal static class AdditiveCumulative
   /// <param name="z">-infinity..+infinity</param>
   public static double Value(double z)
   {
+    // NaN satisfies neither comparison below, so without this it would leave the tail branch as a
+    // finite 0 or 1 and an undefined input would be answered rather than reported.
+    if (double.IsNaN(z))
+      return z;
     double t = Abs(z) / Constants.Sqrt2;
     if (t < 0.5)
     {

--- a/cs/Pragmastat/Functions/ExpFunction.cs
+++ b/cs/Pragmastat/Functions/ExpFunction.cs
@@ -38,11 +38,11 @@ namespace Pragmastat.Functions;
 /// rounds them to even, so naming a rounding is naming a disagreement.
 /// </para>
 /// </remarks>
-internal static class PortableExp
+internal static class ExpFunction
 {
   // Constants of the range reduction, emitted by tests/oracles/fit_exp.py.
   //
-  // ln 2 is split so that k*Ln2Hi is exact: Ln2Hi carries 33 significant bits and |k| needs at
+  // ln 2 is split so that k*Ln2Hi is exact: Ln2Hi carries 32 significant bits and |k| needs at
   // most 11, which leaves the product inside the 53 available. Without the split the reduction
   // would lose the low bits of r, and r is where the accuracy lives.
   private const double InvLn2 = 1.4426950408889634e+00;

--- a/cs/Pragmastat/Functions/PairwiseMargin.cs
+++ b/cs/Pragmastat/Functions/PairwiseMargin.cs
@@ -121,8 +121,8 @@ internal class PairwiseMargin(int threshold = PairwiseMargin.MaxExactSize)
     double su = Sqrt(nm * (n + m + 1) / 12.0);
     // -0.5 continuity correction: computing P(U ≥ u) for a right-tail discrete CDF
     double z = (u - mu - 0.5) / su;
-    double phi = PortableExp.Value(-z.Sqr() / 2) / Sqrt(2 * PI);
-    double Phi = GaussCdf.Value(z);
+    double phi = ExpFunction.Value(-z.Sqr() / 2) / Sqrt(2 * PI);
+    double Phi = AdditiveCumulative.Value(z);
 
     // Pre-compute powers of n and m for efficiency
     double n2 = (double)n * n;

--- a/cs/Pragmastat/Functions/SignedRankMargin.cs
+++ b/cs/Pragmastat/Functions/SignedRankMargin.cs
@@ -109,8 +109,8 @@ internal class SignedRankMargin(int threshold = SignedRankMargin.MaxExactSize)
 
     // +0.5 continuity correction: computing P(W ≤ w) for a left-tail discrete CDF
     double z = (w - mu + 0.5) / sigma;
-    double phi = PortableExp.Value(-z * z / 2) / Sqrt(2 * PI);
-    double Phi = GaussCdf.Value(z);
+    double phi = ExpFunction.Value(-z * z / 2) / Sqrt(2 * PI);
+    double Phi = AdditiveCumulative.Value(z);
 
     double nd = n;
     double kappa4 = -nd * (nd + 1) * (2 * nd + 1) * (3 * nd * nd + 3 * nd - 1) / 240.0;

--- a/cs/tests/approximations/additive_cumulative.json
+++ b/cs/tests/approximations/additive_cumulative.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "name": "gauss_cdf",
+    "name": "additive_cumulative",
     "arg": [
       -3.090252595110711,
       -2.878172129210258,

--- a/go/AGENTS.md
+++ b/go/AGENTS.md
@@ -22,7 +22,8 @@ go/
 ├── sign_margin.go             # Sign margin for binomial CDF inversion
 ├── signed_rank_margin.go      # Signed-rank margin computation
 ├── min_misrate.go             # Minimum achievable misrate calculation
-├── gauss_cdf.go               # Standard normal CDF (ACM Algorithm 209)
+├── additive_cumulative.go            # Standard normal CDF (Chebyshev-fitted erf/erfc)
+├── exp_function.go            # Reproducible exp: range reduction plus fitted polynomial
 ├── rng.go                     # Deterministic xoshiro256++ PRNG
 ├── xoshiro256.go              # PRNG core implementation
 ├── center_impl.go             # O(n log n) Hodges-Lehmann algorithm

--- a/go/additive_cumulative.go
+++ b/go/additive_cumulative.go
@@ -12,6 +12,12 @@ import "math"
 // the kernels are: the Go compiler fuses a multiply into an add on every FMA-capable target
 // and the other six implementations do not.
 func additiveCumulative(z float64) float64 {
+	// NaN reaches neither Horner chain: both comparisons below are false for it, so without
+	// this the tail branch would return a finite 0 or 1 and the caller would never learn that
+	// an undefined input had been asked about. The function it replaced propagated NaN.
+	if math.IsNaN(z) {
+		return z
+	}
 	t := math.Abs(z) / math.Sqrt2
 	if t < 0.5 {
 		s := float64(t * t)

--- a/go/additive_cumulative.go
+++ b/go/additive_cumulative.go
@@ -2,17 +2,17 @@ package pragmastat
 
 import "math"
 
-// gaussCdf computes the standard normal CDF.
+// additiveCumulative computes the standard normal CDF.
 //
 // Two Chebyshev-fitted Horner chains and one exponential. The coefficients are produced by
-// tests/oracles/fit_gauss_cdf.py against a reference good to 36 digits, so they are
+// tests/oracles/fit_additive_cumulative.py against a reference good to 36 digits, so they are
 // reproducible rather than transcribed.
 //
 // Every product is pinned with an explicit float64 conversion for the same reason the rest of
 // the kernels are: the Go compiler fuses a multiply into an add on every FMA-capable target
 // and the other six implementations do not.
-func gaussCdf(x float64) float64 {
-	t := math.Abs(x) / math.Sqrt2
+func additiveCumulative(z float64) float64 {
+	t := math.Abs(z) / math.Sqrt2
 	if t < 0.5 {
 		s := float64(t * t)
 		u := float64(8.0*s) - 1.0
@@ -29,7 +29,7 @@ func gaussCdf(x float64) float64 {
 		p = float64(p*u) - 0.04364205888669792
 		p = float64(p*u) + 1.0830752376761712
 		erf := float64(t * p)
-		if x >= 0 {
+		if z >= 0 {
 			return float64(0.5 * (1.0 + erf))
 		}
 		return float64(0.5 * (1.0 - erf))
@@ -64,9 +64,9 @@ func gaussCdf(x float64) float64 {
 		p = float64(p*u) + 0.09925390090168178
 		p = float64(p*u) - 0.15121195850373031
 		p = float64(p*u) + 0.21849873453703333
-		erfc = float64(portableExp(-float64(t*t)) * p)
+		erfc = float64(expFunction(-float64(t*t)) * p)
 	}
-	if x >= 0 {
+	if z >= 0 {
 		return 1.0 - float64(0.5*erfc)
 	}
 	return float64(0.5 * erfc)

--- a/go/estimators.go
+++ b/go/estimators.go
@@ -280,7 +280,7 @@ func Disparity(x, y []float64, assumeSorted bool) (float64, error) {
 	}
 	avgSpreadVal := (float64(n*spreadX) + float64(m*spreadY)) / (n + m)
 
-	return shiftVal[0] / avgSpreadVal, nil
+	return normalizeZero(shiftVal[0] / avgSpreadVal), nil
 }
 
 // ShiftBounds provides bounds on the Shift estimator with specified misclassification rate.
@@ -393,11 +393,7 @@ func RatioBounds(x, y []float64, misrate float64, assumeSorted bool) (Bounds, er
 		return Bounds{}, err
 	}
 
-	return Bounds{
-		Lower: math.Exp(logBounds.Lower),
-		Upper: math.Exp(logBounds.Upper),
-		Unit:  NumberUnit,
-	}, nil
+	return newBounds(math.Exp(logBounds.Lower), math.Exp(logBounds.Upper), NumberUnit), nil
 }
 
 // CenterBounds provides exact distribution-free bounds for Center (Hodges-Lehmann pseudomedian).
@@ -645,11 +641,11 @@ func avgSpreadBoundsImpl(x, sortedX, y, sortedY []float64, misrate float64, rngX
 	wx := float64(n) / float64(n+m)
 	wy := float64(m) / float64(n+m)
 
-	return Bounds{
-		Lower: float64(wx*boundsX.Lower) + float64(wy*boundsY.Lower),
-		Upper: float64(wx*boundsX.Upper) + float64(wy*boundsY.Upper),
-		Unit:  NumberUnit,
-	}, nil
+	return newBounds(
+		float64(wx*boundsX.Lower)+float64(wy*boundsY.Lower),
+		float64(wx*boundsX.Upper)+float64(wy*boundsY.Upper),
+		NumberUnit,
+	), nil
 }
 
 func disparityBoundsImpl(x, sortedX, y, sortedY []float64, misrate float64, rngX, rngY *Rng) (Bounds, error) {

--- a/go/exp_function.go
+++ b/go/exp_function.go
@@ -8,7 +8,7 @@ import "math"
 
 // Constants of the range reduction, emitted by tests/oracles/fit_exp.py.
 //
-// ln 2 is split so that k*ln2Hi is exact: ln2Hi carries 33 significant bits and |k| needs at
+// ln 2 is split so that k*ln2Hi is exact: ln2Hi carries 32 significant bits and |k| needs at
 // most 11, which leaves the product inside the 53 available. Without the split the reduction
 // would lose the low bits of r, and r is where the accuracy lives.
 const (
@@ -17,7 +17,7 @@ const (
 	ln2Lo  = 1.9082149292705877e-10
 )
 
-// portableExp is the exponential every port evaluates, in place of the platform's.
+// expFunction is the exponential every port evaluates, in place of the platform's.
 //
 // IEEE 754 fixes the result of each arithmetic operation and of the square root, and fixes
 // nothing about the exponential. Conforming libraries disagree in the last bit and do:
@@ -45,7 +45,7 @@ const (
 //
 // floor(x + 1/2) rather than a rounding function: Go rounds halves away from zero and R
 // rounds them to even, so naming a rounding is naming a disagreement.
-func portableExp(y float64) float64 {
+func expFunction(y float64) float64 {
 	if math.IsNaN(y) {
 		return y
 	}

--- a/go/negative_zero_test.go
+++ b/go/negative_zero_test.go
@@ -1,0 +1,272 @@
+package pragmastat
+
+import (
+	"math"
+	"slices"
+	"testing"
+)
+
+// No public estimator reports a negative zero.
+//
+// A sample holding both +0.0 and -0.0 used to make the reported value depend on which of the two
+// the sort happened to leave in the selected position: comparison cannot separate them, so the
+// position was settled by the sorting algorithm rather than by the data, and the seven ports each
+// bring their own sort. Python returned -0.0 for center([0.0, -0.0, 0.0, -0.0, 1.0]) where this
+// port returned +0.0, against an exact conformance class that promises identical bits.
+//
+// Every estimator now sheds the sign on the way out, so these tests compare PAYLOADS. == reads
+// -0.0 and +0.0 as equal, so an equality assertion would pass on exactly the results this file
+// exists to reject; sameFloatBits is the predicate the rest of the suite uses for the same reason.
+//
+// The samples are the ones that reached a negative zero before the fix, plus a sweep that holds
+// the invariant for the estimators where it is currently unreachable. Those are unreachable by
+// proof, not by construction (spread is an absolute difference, ratio is an exponential), and a
+// proof nobody re-checks is how the next divergence gets in. Disparity is here because it was the
+// one exit this port left unwrapped after the other six had been done.
+
+const negativeZeroPayload = 0x8000000000000000
+
+// mixedZeroSamples each estimate to zero, and each selected a -0.0 before the fix.
+var mixedZeroSamples = [][]float64{
+	{0.0, math.Copysign(0, -1), 0.0, math.Copysign(0, -1), 1.0},
+	{math.Copysign(0, -1), math.Copysign(0, -1)},
+	{math.Copysign(0, -1), 0.0},
+	{0.0, math.Copysign(0, -1)},
+	{math.Copysign(0, -1), math.Copysign(0, -1), math.Copysign(0, -1)},
+	{-1.0, 1.0},
+	{-2.0, math.Copysign(0, -1), 2.0},
+}
+
+var (
+	mixedSample    = []float64{0.0, math.Copysign(0, -1), 0.0, math.Copysign(0, -1), 1.0, -1.0}
+	positiveSample = []float64{1.0, 2.0, 3.0, 4.0, 5.0, 6.0}
+)
+
+func assertPositiveZero(t *testing.T, value float64, what string) {
+	t.Helper()
+	if !sameFloatBits(value, 0.0) {
+		t.Errorf("%s = %s, want %s", what, formatFloatBits(value), formatFloatBits(0.0))
+	}
+}
+
+func assertNotNegativeZero(t *testing.T, value float64, what string) {
+	t.Helper()
+	if math.Float64bits(value) == negativeZeroPayload {
+		t.Errorf("%s reported a negative zero: %s", what, formatFloatBits(value))
+	}
+}
+
+func TestCenterReportsPositiveZero(t *testing.T) {
+	for _, x := range mixedZeroSamples {
+		value, err := Center(x, false)
+		if err != nil {
+			t.Fatalf("Center(%v): %v", x, err)
+		}
+		assertPositiveZero(t, value, "Center")
+
+		sample, err := NewSample(x)
+		if err != nil {
+			t.Fatalf("NewSample(%v): %v", x, err)
+		}
+		measurement, err := sample.Center()
+		if err != nil {
+			t.Fatalf("Sample.Center(%v): %v", x, err)
+		}
+		assertPositiveZero(t, measurement.Value, "Sample.Center")
+	}
+}
+
+func TestShiftReportsPositiveZero(t *testing.T) {
+	pairs := [][2][]float64{
+		{{math.Copysign(0, -1)}, {0.0}},
+		{{math.Copysign(0, -1), 1.0}, {0.0, 1.0}},
+		{{math.Copysign(0, -1), math.Copysign(0, -1)}, {0.0, 0.0}},
+	}
+	for _, pair := range pairs {
+		value, err := Shift(pair[0], pair[1], false)
+		if err != nil {
+			t.Fatalf("Shift(%v, %v): %v", pair[0], pair[1], err)
+		}
+		assertPositiveZero(t, value, "Shift")
+	}
+}
+
+func TestDisparityReportsPositiveZero(t *testing.T) {
+	// Shift selects the -0.0 difference; the average spread is positive, so the sign survived.
+	x := []float64{math.Copysign(0, -1), 1.0}
+	y := []float64{0.0, 1.0}
+	value, err := Disparity(x, y, false)
+	if err != nil {
+		t.Fatalf("Disparity: %v", err)
+	}
+	assertPositiveZero(t, value, "Disparity")
+
+	sx, err := NewSample(x)
+	if err != nil {
+		t.Fatalf("NewSample(x): %v", err)
+	}
+	sy, err := NewSample(y)
+	if err != nil {
+		t.Fatalf("NewSample(y): %v", err)
+	}
+	measurement, err := sx.Disparity(sy)
+	if err != nil {
+		t.Fatalf("Sample.Disparity: %v", err)
+	}
+	assertPositiveZero(t, measurement.Value, "Sample.Disparity")
+}
+
+func TestBoundsReportPositiveZeros(t *testing.T) {
+	// A single pair takes the degenerate x[0] - y[0] path, where -0.0 - +0.0 is -0.0.
+	bounds, err := ShiftBounds([]float64{math.Copysign(0, -1)}, []float64{0.0}, 1.0, false)
+	if err != nil {
+		t.Fatalf("ShiftBounds: %v", err)
+	}
+	assertPositiveZero(t, bounds.Lower, "ShiftBounds lower")
+	assertPositiveZero(t, bounds.Upper, "ShiftBounds upper")
+
+	centerBounds, err := CenterBounds(mixedSample, 0.3, false)
+	if err != nil {
+		t.Fatalf("CenterBounds: %v", err)
+	}
+	assertPositiveZero(t, centerBounds.Lower, "CenterBounds lower")
+	assertPositiveZero(t, centerBounds.Upper, "CenterBounds upper")
+}
+
+// TestNoEstimatorReportsNegativeZero sweeps every public exit, including the ones where a negative
+// zero is currently unreachable. Reachability is what changes when the arithmetic behind an exit
+// changes, so the sweep is the part that keeps holding after such a change.
+func TestNoEstimatorReportsNegativeZero(t *testing.T) {
+	scalar := []struct {
+		name  string
+		value func() (float64, error)
+	}{
+		{"Center", func() (float64, error) { return Center(mixedSample, false) }},
+		{"Spread", func() (float64, error) { return Spread(mixedSample, false) }},
+		{"Shift", func() (float64, error) { return Shift(mixedSample, mixedSample, false) }},
+		{"Ratio", func() (float64, error) { return Ratio(positiveSample, positiveSample, false) }},
+		{"Disparity", func() (float64, error) { return Disparity(mixedSample, mixedSample, false) }},
+		{"avgSpread", func() (float64, error) { return avgSpread(mixedSample, mixedSample, false) }},
+	}
+	for _, c := range scalar {
+		value, err := c.value()
+		if err != nil {
+			t.Fatalf("%s: %v", c.name, err)
+		}
+		assertNotNegativeZero(t, value, c.name)
+	}
+
+	bounded := []struct {
+		name   string
+		bounds func() (Bounds, error)
+	}{
+		{"CenterBounds", func() (Bounds, error) { return CenterBounds(mixedSample, 0.3, false) }},
+		{"SpreadBounds", func() (Bounds, error) { return SpreadBoundsWithSeed(mixedSample, 0.5, "seed", false) }},
+		{"ShiftBounds", func() (Bounds, error) { return ShiftBounds(mixedSample, mixedSample, 0.5, false) }},
+		{"RatioBounds", func() (Bounds, error) { return RatioBounds(positiveSample, positiveSample, 0.5, false) }},
+		{"DisparityBounds", func() (Bounds, error) {
+			return DisparityBoundsWithSeed(mixedSample, mixedSample, 0.9, "seed", false)
+		}},
+		{"avgSpreadBounds", func() (Bounds, error) {
+			sorted := append([]float64(nil), mixedSample...)
+			slices.Sort(sorted)
+			return avgSpreadBoundsImpl(mixedSample, sorted, mixedSample, sorted, 0.9,
+				NewRngFromString("seed"), NewRngFromString("seed"))
+		}},
+	}
+	for _, c := range bounded {
+		bounds, err := c.bounds()
+		if err != nil {
+			t.Fatalf("%s: %v", c.name, err)
+		}
+		assertNotNegativeZero(t, bounds.Lower, c.name+" lower")
+		assertNotNegativeZero(t, bounds.Upper, c.name+" upper")
+	}
+}
+
+func TestInputsKeepTheirNegativeZeros(t *testing.T) {
+	// Only outputs are normalized: a sample must still be able to CONTAIN a -0.0.
+	x := []float64{0.0, math.Copysign(0, -1), 0.0, math.Copysign(0, -1), 1.0}
+	if _, err := Center(x, false); err != nil {
+		t.Fatalf("Center: %v", err)
+	}
+	if math.Float64bits(x[1]) != negativeZeroPayload {
+		t.Errorf("input was rewritten: %s", formatFloatBits(x[1]))
+	}
+
+	sample, err := NewSample(x)
+	if err != nil {
+		t.Fatalf("NewSample: %v", err)
+	}
+	if _, err := sample.Center(); err != nil {
+		t.Fatalf("Sample.Center: %v", err)
+	}
+	for _, v := range sample.cachedSortedValues() {
+		if math.Float64bits(v) == negativeZeroPayload {
+			return
+		}
+	}
+	t.Error("sorted values were rewritten: no negative zero left in the sample")
+}
+
+func TestNormalizeZeroLeavesEveryNonZeroAlone(t *testing.T) {
+	values := []float64{1.0, -1.0, 1e-320, -1e-320, math.Inf(1), math.Inf(-1), math.NaN(), 5e-324, -5e-324}
+	for _, v := range values {
+		if !sameFloatBits(normalizeZero(v), v) {
+			t.Errorf("normalizeZero(%s) = %s", formatFloatBits(v), formatFloatBits(normalizeZero(v)))
+		}
+	}
+}
+
+func TestNormalizeZeroMapsBothZerosToThePositiveOne(t *testing.T) {
+	for _, v := range []float64{0.0, math.Copysign(0, -1)} {
+		assertPositiveZero(t, normalizeZero(v), "normalizeZero")
+	}
+}
+
+func TestNewBoundsNormalizesBothEndpoints(t *testing.T) {
+	bounds := newBounds(math.Copysign(0, -1), math.Copysign(0, -1), NumberUnit)
+	assertPositiveZero(t, bounds.Lower, "lower")
+	assertPositiveZero(t, bounds.Upper, "upper")
+
+	infinite := newBounds(math.Inf(-1), math.Inf(1), NumberUnit)
+	if !sameFloatBits(infinite.Lower, math.Inf(-1)) || !sameFloatBits(infinite.Upper, math.Inf(1)) {
+		t.Error("newBounds rewrote an infinite endpoint")
+	}
+}
+
+// TestAdditiveCumulativePropagatesNaN pins the one input for which the function has no answer. Both of
+// its range comparisons are false for a NaN, so without the guard it leaves the tail branch as a
+// finite 0 or 1: an undefined input answered rather than reported.
+func TestAdditiveCumulativePropagatesNaN(t *testing.T) {
+	if !math.IsNaN(additiveCumulative(math.NaN())) {
+		t.Errorf("additiveCumulative(NaN) = %s, want NaN", formatFloatBits(additiveCumulative(math.NaN())))
+	}
+	if !sameFloatBits(additiveCumulative(math.Inf(1)), 1.0) {
+		t.Errorf("additiveCumulative(+Inf) = %s, want 1", formatFloatBits(additiveCumulative(math.Inf(1))))
+	}
+	if !sameFloatBits(additiveCumulative(math.Inf(-1)), 0.0) {
+		t.Errorf("additiveCumulative(-Inf) = %s, want 0", formatFloatBits(additiveCumulative(math.Inf(-1))))
+	}
+	if !sameFloatBits(additiveCumulative(0.0), 0.5) || !sameFloatBits(additiveCumulative(math.Copysign(0, -1)), 0.5) {
+		t.Error("additiveCumulative disagreed with itself on the two zeros")
+	}
+}
+
+// TestExpFunctionCutoffs pins the values outside the reduction band, where a language can name
+// its infinity and JSON cannot: the shared fixture stops at 709.78 for that reason, so these
+// arguments are covered here or nowhere.
+func TestExpFunctionCutoffs(t *testing.T) {
+	if !math.IsNaN(expFunction(math.NaN())) {
+		t.Error("expFunction(NaN) should be NaN")
+	}
+	if !math.IsInf(expFunction(709.8), 1) || !math.IsInf(expFunction(math.Inf(1)), 1) {
+		t.Error("expFunction should overflow to +Inf above the cutoff")
+	}
+	if !sameFloatBits(expFunction(-745.3), 0.0) || !sameFloatBits(expFunction(math.Inf(-1)), 0.0) {
+		t.Error("expFunction should underflow to +0 below the cutoff")
+	}
+	if !sameFloatBits(expFunction(0.0), 1.0) {
+		t.Error("expFunction(0) should be exactly 1")
+	}
+}

--- a/go/pairwise_margin.go
+++ b/go/pairwise_margin.go
@@ -171,8 +171,8 @@ func edgeworthCdf(n, m int, u int64) float64 {
 	su := math.Sqrt(nm * float64(n+m+1) / 12.0)
 	// -0.5 continuity correction: computing P(U ≥ u) for a right-tail discrete CDF
 	z := (float64(u) - mu - 0.5) / su
-	phi := portableExp(-z*z/2) / math.Sqrt(2*math.Pi)
-	Phi := gaussCdf(z)
+	phi := expFunction(-z*z/2) / math.Sqrt(2*math.Pi)
+	Phi := additiveCumulative(z)
 
 	// Pre-compute powers of n and m as float64 (avoids int64 overflow for large n, m)
 	nf := float64(n)

--- a/go/reference_test.go
+++ b/go/reference_test.go
@@ -1808,16 +1808,16 @@ type SingleDoubleValueInput struct {
 	Arg  []float64 `json:"arg"`
 }
 
-// portableExpArgCount is how many arguments the portable-exp fixtures carry
+// expFunctionArgCount is how many arguments the exp-function fixtures carry
 // between them: 401 over the band exp(-t*t) reaches, 201 over the wider band the
 // Edgeworth expansion reaches, 401 over the whole finite range, and 29
 // boundaries. It is asserted because a loader that finds no files, or three
 // files out of four, passes every other check in this test.
-const portableExpArgCount = 1032
+const expFunctionArgCount = 1032
 
-// TestPortableExpReference checks the reproducible exponential directly.
+// TestExpFunctionReference checks the reproducible exponential directly.
 //
-// Every other suite reaches portableExp only through a margin, which evaluates
+// Every other suite reaches expFunction only through a margin, which evaluates
 // it wherever an Edgeworth expansion happens to look and nowhere else. The
 // exact class of all those suites rests on this one function agreeing in all
 // seven languages, so it is worth checking on its own arguments rather than
@@ -1833,11 +1833,11 @@ const portableExpArgCount = 1032
 // both; both map to exp(0) = 1, and the suite makes no claim about the payload
 // of an input. The outputs do reach down to the smallest denormal, and
 // comparing those by payload is what shows the parser round-trips them.
-func TestPortableExpReference(t *testing.T) {
+func TestExpFunctionReference(t *testing.T) {
 	checked := 0
-	forEachFixture(t, "portable-exp", func(t *testing.T, td TestData, input SingleDoubleValueInput) {
-		if input.Name != "portable_exp" {
-			t.Fatalf("Fixture names function %q, want %q", input.Name, "portable_exp")
+	forEachFixture(t, "exp-function", func(t *testing.T, td TestData, input SingleDoubleValueInput) {
+		if input.Name != "exp_function" {
+			t.Fatalf("Fixture names function %q, want %q", input.Name, "exp_function")
 		}
 		var expected []float64
 		if err := json.Unmarshal(td.Output, &expected); err != nil {
@@ -1847,12 +1847,12 @@ func TestPortableExpReference(t *testing.T) {
 			t.Fatalf("Fixture has %d arguments and %d outputs", len(input.Arg), len(expected))
 		}
 		for i, arg := range input.Arg {
-			label := fmt.Sprintf("portableExp(%s)", formatFloatBits(arg))
-			assertFloat(t, compareExact, label, portableExp(arg), expected[i])
+			label := fmt.Sprintf("expFunction(%s)", formatFloatBits(arg))
+			assertFloat(t, compareExact, label, expFunction(arg), expected[i])
 		}
 		checked += len(input.Arg)
 	})
-	if checked != portableExpArgCount {
-		t.Errorf("Checked %d arguments, want %d", checked, portableExpArgCount)
+	if checked != expFunctionArgCount {
+		t.Errorf("Checked %d arguments, want %d", checked, expFunctionArgCount)
 	}
 }

--- a/go/signed_rank_margin.go
+++ b/go/signed_rank_margin.go
@@ -125,8 +125,8 @@ func signedRankEdgeworthCdf(n int, w int64) float64 {
 
 	// +0.5 continuity correction: computing P(W ≤ w) for a left-tail discrete CDF
 	z := (float64(w) - mu + 0.5) / sigma
-	phi := portableExp(-z*z/2) / math.Sqrt(2*math.Pi)
-	Phi := gaussCdf(z)
+	phi := expFunction(-z*z/2) / math.Sqrt(2*math.Pi)
+	Phi := additiveCumulative(z)
 
 	nf := float64(n)
 	kappa4 := -nf * (nf + 1) * (float64(2*nf) + 1) * (float64(3*nf*nf) + float64(3*nf) - 1) / 240.0

--- a/kt/AGENTS.md
+++ b/kt/AGENTS.md
@@ -28,8 +28,8 @@ kt/
 │   ├── SignMargin.kt            # Sign margin for binomial CDF inversion
 │   ├── SignedRankMargin.kt      # Signed-rank margin computation
 │   ├── MinMisrate.kt            # Minimum achievable misrate calculation
-│   ├── GaussCdf.kt              # Standard normal CDF (Chebyshev-fitted erf/erfc)
-│   ├── PortableExp.kt           # Reproducible exp: range reduction plus fitted polynomial
+│   ├── AdditiveCumulative.kt           # Standard normal CDF (Chebyshev-fitted erf/erfc)
+│   ├── ExpFunction.kt           # Reproducible exp: range reduction plus fitted polynomial
 │   ├── Rng.kt                   # Deterministic xoshiro256++ PRNG
 │   ├── Xoshiro256.kt            # PRNG core implementation
 │   ├── CenterImpl.kt            # O(n log n) Hodges-Lehmann algorithm
@@ -52,6 +52,7 @@ kt/
 │   ├── AssumeSortedTest.kt                # Raw-API assumeSorted=true branch coverage
 │   ├── MutationTest.kt                    # Estimators must not mutate caller lists
 │   ├── CenterMidpointSymmetryTest.kt      # n==2 midpoint exact order symmetry
+│   ├── NegativeZeroTest.kt                # No estimator reports a negative zero
 │   ├── BoundsUnitTest.kt                  # Bounds unit propagation (Sample vs raw)
 │   ├── ProbabilityTest.kt                 # Probability [0, 1] range validation
 │   ├── RawMisrateDomainTest.kt            # Raw-API misrate domain errors
@@ -119,7 +120,8 @@ class Multiplic(location: Double, scale: Double) : Distribution
   binary64 payloads (`toRawBits`), never `==` (which passes `-0.0` against `+0.0`
   and fails a pair of identical NaNs) and never boxed `equals` (which collapses
   every NaN payload into one), and every failure prints both payloads in hex next
-  to the decimal values.
+  to the decimal values. It also holds the negated form, "this value is not a
+  negative zero", for the positions where only the sign of a zero is being pinned.
 - **Tolerance**: `1e-9`, for the genuinely approximate suites only (ratio,
   ratio-bounds, compare2, the transcendental distributions, invariance)
 

--- a/kt/src/main/kotlin/dev/pragmastat/AdditiveCumulative.kt
+++ b/kt/src/main/kotlin/dev/pragmastat/AdditiveCumulative.kt
@@ -18,6 +18,11 @@ import kotlin.math.sqrt
  * @return Area under the Standard Normal Curve from -infinity to x
  */
 internal fun additiveCumulative(z: Double): Double {
+    // NaN satisfies neither comparison below, so without this it would leave the tail branch as a
+    // finite 0 or 1 and an undefined input would be answered rather than reported.
+    if (z.isNaN()) {
+        return z
+    }
     val t = abs(z) / sqrt(2.0)
     if (t < 0.5) {
         val s = t * t

--- a/kt/src/main/kotlin/dev/pragmastat/AdditiveCumulative.kt
+++ b/kt/src/main/kotlin/dev/pragmastat/AdditiveCumulative.kt
@@ -1,37 +1,28 @@
-"""Standard normal CDF.
+package dev.pragmastat
 
-Two Chebyshev-fitted Horner chains and one exponential. The coefficients are produced by
-tests/oracles/fit_gauss_cdf.py against a reference good to 36 digits, so they are
-reproducible rather than transcribed.
+import kotlin.math.abs
+import kotlin.math.sqrt
 
-No rounding pins are needed here: Python evaluates every product and every sum as a
-separate binary64 operation and has no multiply-add contraction to disable. Plain floats
-only, since a numpy expression may reassociate.
-"""
-
-import math
-
-from .portable_exp import portable_exp
-
-_SQRT2 = math.sqrt(2.0)
-
-
-def gauss_cdf(x: float) -> float:
-    """
-    Computes the standard normal CDF.
-
-    Args:
-        x: -infinity..+infinity
-
-    Returns:
-        Area under the standard normal curve from -infinity to x
-    """
-    t = abs(x) / _SQRT2
-    if t < 0.5:
-        # erf(t) / t as a polynomial in u = 8 * t^2 - 1
-        s = t * t
-        u = 8.0 * s - 1.0
-        p = -1.2757552949301143e-19
+/**
+ * Computes the standard normal CDF.
+ *
+ * Two Chebyshev-fitted Horner chains and one exponential. The coefficients are produced by
+ * tests/oracles/fit_additive_cumulative.py against a reference good to 36 digits, so they are
+ * reproducible rather than transcribed.
+ *
+ * No rounding pins are needed here: the JVM never contracts a multiply and an add into a fused
+ * multiply-add, so every product lands in binary64 on its own, which is what the Go port has to
+ * spell out with explicit float64 conversions.
+ *
+ * @param x Value in range (-infinity, +infinity)
+ * @return Area under the Standard Normal Curve from -infinity to x
+ */
+internal fun additiveCumulative(z: Double): Double {
+    val t = abs(z) / sqrt(2.0)
+    if (t < 0.5) {
+        val s = t * t
+        val u = 8.0 * s - 1.0
+        var p = -1.2757552949301143e-19
         p = p * u + 1.2307154179828511e-17
         p = p * u - 1.0890239994332592e-15
         p = p * u + 8.774530700097397e-14
@@ -43,16 +34,14 @@ def gauss_cdf(x: float) -> float:
         p = p * u + 0.0016130716680617086
         p = p * u - 0.04364205888669792
         p = p * u + 1.0830752376761712
-        erf = t * p
-        if x >= 0:
-            return 0.5 * (1.0 + erf)
-        return 0.5 * (1.0 - erf)
+        val erf = t * p
+        return if (z >= 0.0) 0.5 * (1.0 + erf) else 0.5 * (1.0 - erf)
+    }
 
-    erfc = 0.0
-    if t <= 4.3:
-        # erfc(t) * exp(t^2) as a polynomial in u = (2 * t - 4.8) / 3.8
-        u = (2.0 * t - 4.8) / 3.8
-        p = 2.403093649825437e-09
+    var erfc = 0.0
+    if (t <= 4.3) {
+        val u = (2.0 * t - 4.8) / 3.8
+        var p = 2.403093649825437e-09
         p = p * u - 6.533436159455495e-09
         p = p * u + 1.334437871983186e-09
         p = p * u - 2.5055474016226743e-09
@@ -79,8 +68,8 @@ def gauss_cdf(x: float) -> float:
         p = p * u + 0.09925390090168178
         p = p * u - 0.15121195850373031
         p = p * u + 0.21849873453703333
-        erfc = portable_exp(-(t * t)) * p
+        erfc = expFunction(-(t * t)) * p
+    }
 
-    if x >= 0:
-        return 1.0 - 0.5 * erfc
-    return 0.5 * erfc
+    return if (z >= 0.0) 1.0 - 0.5 * erfc else 0.5 * erfc
+}

--- a/kt/src/main/kotlin/dev/pragmastat/ExpFunction.kt
+++ b/kt/src/main/kotlin/dev/pragmastat/ExpFunction.kt
@@ -4,7 +4,7 @@ import kotlin.math.floor
 
 // Constants of the range reduction, emitted by tests/oracles/fit_exp.py.
 //
-// ln 2 is split so that k*LN2_HI is exact: LN2_HI carries 33 significant bits and |k| needs at
+// ln 2 is split so that k*LN2_HI is exact: LN2_HI carries 32 significant bits and |k| needs at
 // most 11, which leaves the product inside the 53 available. Without the split the reduction
 // would lose the low bits of r, and r is where the accuracy lives.
 private const val INV_LN2 = 1.4426950408889634e+00
@@ -48,7 +48,7 @@ private const val LN2_LO = 1.9082149292705877e-10
  * @param y Exponent
  * @return e raised to the power of [y]
  */
-internal fun portableExp(y: Double): Double {
+internal fun expFunction(y: Double): Double {
     if (y.isNaN()) {
         return y
     }

--- a/kt/src/main/kotlin/dev/pragmastat/PairwiseMargin.kt
+++ b/kt/src/main/kotlin/dev/pragmastat/PairwiseMargin.kt
@@ -164,8 +164,8 @@ private fun edgeworthCdf(
     val z = (uf - mu - 0.5) / su
 
     // Standard normal PDF and CDF
-    val phi = portableExp((-z * z) / 2.0) / sqrt(2.0 * PI)
-    val bigPhi = gaussCdf(z)
+    val phi = expFunction((-z * z) / 2.0) / sqrt(2.0 * PI)
+    val bigPhi = additiveCumulative(z)
 
     // Pre-compute powers of n and m for efficiency
     val n2 = nf * nf

--- a/kt/src/main/kotlin/dev/pragmastat/SignedRankMargin.kt
+++ b/kt/src/main/kotlin/dev/pragmastat/SignedRankMargin.kt
@@ -132,8 +132,8 @@ private fun edgeworthCdf(
     val sigma = sqrt(sigma2)
 
     val z = (w - mu + 0.5) / sigma
-    val phi = portableExp(-z * z / 2) / sqrt(2 * PI)
-    val bigPhi = gaussCdf(z)
+    val phi = expFunction(-z * z / 2) / sqrt(2 * PI)
+    val bigPhi = additiveCumulative(z)
 
     val nk = n.toDouble()
     val kappa4 = -nk * (nk + 1) * (2 * nk + 1) * (3 * nk * nk + 3 * nk - 1) / 240.0

--- a/kt/src/test/kotlin/dev/pragmastat/AdditiveCumulativeTest.kt
+++ b/kt/src/test/kotlin/dev/pragmastat/AdditiveCumulativeTest.kt
@@ -1,0 +1,39 @@
+package dev.pragmastat
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * [additiveCumulative] has no answer for a NaN, and both of its range comparisons are false for one, so
+ * without an explicit guard it leaves the tail branch as a finite 0 or 1: an undefined input
+ * answered rather than reported. The approximation it replaced propagated NaN, so losing that
+ * would be a regression on behavior every port shares.
+ *
+ * The assertions compare PAYLOADS. `==` reads the two zeros as equal and every NaN as unequal,
+ * neither of which is the claim being made here.
+ */
+class AdditiveCumulativeTest {
+    @Test
+    fun carriesNaNThroughAndAnswersBothInfinities() {
+        assertTrue(additiveCumulative(Double.NaN).isNaN(), "additiveCumulative(NaN) should be NaN")
+        assertBitwise(1.0, additiveCumulative(Double.POSITIVE_INFINITY), "additiveCumulative(+Inf)")
+        assertBitwise(0.0, additiveCumulative(Double.NEGATIVE_INFINITY), "additiveCumulative(-Inf)")
+        assertBitwise(0.5, additiveCumulative(0.0), "additiveCumulative(+0)")
+        assertBitwise(0.5, additiveCumulative(-0.0), "additiveCumulative(-0)")
+    }
+
+    /**
+     * The values outside the reduction band, which the shared fixture cannot carry: JSON has no
+     * way to express an infinity, so the generated suite stops at 709.78 and these arguments are
+     * covered here or nowhere.
+     */
+    @Test
+    fun expFunctionReturnsTheDeclaredValuesOutsideTheReductionBand() {
+        assertTrue(expFunction(Double.NaN).isNaN(), "expFunction(NaN) should be NaN")
+        assertBitwise(Double.POSITIVE_INFINITY, expFunction(709.8), "expFunction(709.8)")
+        assertBitwise(Double.POSITIVE_INFINITY, expFunction(Double.POSITIVE_INFINITY), "expFunction(+Inf)")
+        assertBitwise(0.0, expFunction(-745.3), "expFunction(-745.3)")
+        assertBitwise(0.0, expFunction(Double.NEGATIVE_INFINITY), "expFunction(-Inf)")
+        assertBitwise(1.0, expFunction(0.0), "expFunction(0)")
+    }
+}

--- a/kt/src/test/kotlin/dev/pragmastat/ReferenceTest.kt
+++ b/kt/src/test/kotlin/dev/pragmastat/ReferenceTest.kt
@@ -135,6 +135,13 @@ class ReferenceTest {
     private val mapper = ObjectMapper().registerModule(KotlinModule.Builder().build())
     private val epsilon = 1e-9
 
+    private companion object {
+        // The size of the generated exp-function fixture: 1032 arguments over four files. Pinned
+        // rather than counted from the directory, because counting the directory and asserting
+        // the count matches it asserts nothing.
+        const val EXP_FUNCTION_ARGUMENT_COUNT = 1032
+    }
+
     /**
      * Create the y-argument sample for the Sample-based two-sample path.
      *
@@ -1739,7 +1746,15 @@ class ReferenceTest {
                     found.containsAll(expectedFiles),
                     "Expected exp-function fixtures $expectedFiles but found $found",
                 )
-                assertTrue(total > 0, "exp-function fixtures carry no arguments")
+                // The argument count is pinned, not merely required to be positive. A file that
+                // keeps its name and loses its contents satisfies both assertions above, and the
+                // other six ports pin this number, so a truncated fixture would show up as this
+                // port alone still passing.
+                assertEquals(
+                    EXP_FUNCTION_ARGUMENT_COUNT,
+                    total,
+                    "exp-function: loaded $total arguments, expected $EXP_FUNCTION_ARGUMENT_COUNT",
+                )
             },
         )
 

--- a/kt/src/test/kotlin/dev/pragmastat/ReferenceTest.kt
+++ b/kt/src/test/kotlin/dev/pragmastat/ReferenceTest.kt
@@ -1674,7 +1674,7 @@ class ReferenceTest {
 
     /**
      * The shape of a single-value suite: one function name, one vector of arguments,
-     * one vector of results. Named for the shape rather than for `portable-exp`,
+     * one vector of results. Named for the shape rather than for `exp-function`,
      * which is the only such suite this port loads today.
      */
     data class SingleDoubleValueInput(
@@ -1689,7 +1689,7 @@ class ReferenceTest {
     )
 
     /**
-     * [portableExp] against the shared fixture, argument by argument, bit for bit.
+     * [expFunction] against the shared fixture, argument by argument, bit for bit.
      *
      * The seven ports carry their own exponential because IEEE 754 fixes nothing
      * about one and a margin selects an order statistic, so a last-bit difference is
@@ -1709,11 +1709,11 @@ class ReferenceTest {
      *   asserted.
      * - The expected results run down to the smallest denormal (`1e-323`, `5e-324`).
      *   Comparing those by payload is also what proves Jackson round-trips them: a
-     *   parser that mangles a subnormal cannot agree with [portableExp] bit for bit.
+     *   parser that mangles a subnormal cannot agree with [expFunction] bit for bit.
      */
     @TestFactory
-    fun testPortableExp(): List<DynamicTest> {
-        val testDir = File("../tests/portable-exp")
+    fun testExpFunction(): List<DynamicTest> {
+        val testDir = File("../tests/exp-function")
         val loaded =
             testDir
                 .listFiles { _, name -> name.endsWith(".json") }
@@ -1733,20 +1733,20 @@ class ReferenceTest {
         // argument count rides in the test name so a report states the coverage.
         val expectedFiles = listOf("boundaries", "edgeworth-band", "finite-range", "working-band")
         tests.add(
-            DynamicTest.dynamicTest("portable-exp/coverage: $total arguments over ${loaded.size} files") {
+            DynamicTest.dynamicTest("exp-function/coverage: $total arguments over ${loaded.size} files") {
                 val found = loaded.map { (name, _) -> name }
                 assertTrue(
                     found.containsAll(expectedFiles),
-                    "Expected portable-exp fixtures $expectedFiles but found $found",
+                    "Expected exp-function fixtures $expectedFiles but found $found",
                 )
-                assertTrue(total > 0, "portable-exp fixtures carry no arguments")
+                assertTrue(total > 0, "exp-function fixtures carry no arguments")
             },
         )
 
         for ((name, data) in loaded) {
             tests.add(
-                DynamicTest.dynamicTest("portable-exp/$name (${data.input.arg.size} arguments)") {
-                    assertEquals("portable_exp", data.input.name, "$name: unexpected function name")
+                DynamicTest.dynamicTest("exp-function/$name (${data.input.arg.size} arguments)") {
+                    assertEquals("exp_function", data.input.name, "$name: unexpected function name")
                     assertEquals(
                         data.input.arg.size,
                         data.output.size,
@@ -1755,7 +1755,7 @@ class ReferenceTest {
                     // The argument, not the index, goes in the label: a one-ulp report on
                     // a 401-point grid is only actionable if it names the point.
                     for (i in data.input.arg.indices) {
-                        assertBitwise(data.output[i], portableExp(data.input.arg[i]), "portableExp(${data.input.arg[i]})")
+                        assertBitwise(data.output[i], expFunction(data.input.arg[i]), "expFunction(${data.input.arg[i]})")
                     }
                 },
             )

--- a/manual/additive-cumulative/additive-cumulative-algorithm.typ
+++ b/manual/additive-cumulative/additive-cumulative-algorithm.typ
@@ -1,0 +1,75 @@
+#import "/manual/definitions.typ": *
+
+The $AdditiveCumulative$ function evaluates the distribution function of the standard $Additive$
+  ('Normal') distribution through the error function, in the substitution $t = abs(z) \/ sqrt(2)$:
+
+$ AdditiveCumulative(z) = cases(
+  (1 + "erf"(t)) \/ 2 & "for " z >= 0,
+  "erfc"(t) \/ 2 & "for " z < 0,
+) $
+
+Two regimes follow, because no single polynomial covers the whole range.
+Near the center the function is smooth and bounded away from zero, so a polynomial reproduces it
+  directly.
+In the tail it decays like $e^(-t^2)$, and no polynomial of any degree follows exponential decay,
+  so the decay is factored out and only the slowly varying remainder is approximated.
+
+*Central regime* ($t < 1 \/ 2$)
+
+The quantity approximated is $"erf"(t) \/ t$ rather than $"erf"(t)$ itself.
+The error function is odd, which makes that ratio even, which in turn makes it a function of $t^2$
+  alone:
+
+$ "erf"(t) = t dot P_A (s), quad s = t^2 in [0, 1 \/ 4] $
+
+Working in $s$ halves the degree the fit requires, since every odd power vanishes by construction
+  rather than through the fit discovering that its coefficient is zero.
+$P_A$ carries 12 coefficients and is evaluated by Horner's method in $u = 8 s - 1$, which maps
+  $[0, 1\/4]$ onto $[-1, 1]$.
+
+*Tail regime* ($1 \/ 2 <= t <= 4.3$)
+
+The quantity approximated is $"erfc"(t) dot e^(t^2)$, which behaves like $1 \/ (t sqrt(pi))$.
+That product is smooth and slowly varying, and therefore suited to a polynomial where $"erfc"$
+  itself is not:
+
+$ "erfc"(t) = e^(-t^2) dot P_B (u), quad u = (2 t - 4.8) \/ 3.8 $
+
+$P_B$ carries 27 coefficients on the same normalized variable.
+The exponential is #link(<sec-exp-function>)[$ExpFunction$] rather than the platform's, for the
+  reason given in that section.
+
+*Beyond the tail* ($t > 4.3$)
+
+The complementary error function is taken as zero, which makes the distribution function return
+  exactly $0$ or exactly $1$ past $abs(z) = 6.08$.
+The truncated quantity there is $"erfc"(4.3) \/ 2 approx 6 dot 10^(-10)$, so the result is not
+  merely imprecise beyond that point: it is wrong by a relative error of $1$, as any approximation
+  that stops is.
+
+The cutoff is placed where no estimator reaches rather than where the truncated value becomes
+  negligible, and the accuracy claim below is scoped to $abs(z) <= 6$ for the same reason.
+Both margins evaluate this function on a standardized statistic whose magnitude stays far inside
+  that range for every sample size the Edgeworth branches serve.
+
+*Origin of the coefficients*
+
+Both chains are Chebyshev interpolations (@trefethen2019) computed at 80 decimal digits against a
+  reference built from two convergent expansions: the Taylor series for $"erf"$ below $2.5$, and a
+  continued fraction for $"erfc"$ above it.
+Splitting the range at a transformed $"erfc"$ follows the strategy Cody established for rational
+  approximations to the same function (@cody1969); the approximations here are polynomial rather
+  than rational.
+The two agree to 36 digits where they overlap, which establishes the reference through internal
+  consistency rather than through an appeal to an outside implementation.
+
+A script that ships with the toolkit produces the coefficients, so they can be recomputed rather
+  than only compared against the source they were transcribed from.
+
+*Accuracy*
+
+The worst relative error is $9.1 dot 10^(-15)$ over $abs(z) <= 6$, evaluated in binary64 against
+  the same reference.
+The degree of $P_B$ was selected where additional terms stop being visible in binary64: degree 13
+  yields $5.9 dot 10^(-8)$, degree 17 yields $1.5 dot 10^(-10)$, degree 21 yields
+  $2.7 dot 10^(-13)$, and degree 25 yields $4.0 dot 10^(-16)$.

--- a/manual/additive-cumulative/additive-cumulative-notes.typ
+++ b/manual/additive-cumulative/additive-cumulative-notes.typ
@@ -1,0 +1,80 @@
+#import "/manual/definitions.typ": *
+
+*Why accuracy matters for this function*
+
+A distribution function accurate to seven digits satisfies most uses it is put to.
+The Edgeworth branches of the two margins are not among them, because of what happens to the value
+  after it is computed.
+
+Each margin compares the value against a misrate, the comparison decides an integer index, and that
+  index selects an order statistic out of the sorted sample.
+No intermediate quantity absorbs a small error.
+Either the comparison yields the same index and the answer is identical to the last bit, or it
+  yields a different one and the reported bound moves to a different observation, separated by a
+  distance the data sets rather than the arithmetic.
+
+This property determines how the function is built.
+The requirement is not accuracy in the abstract but accuracy sufficient to select the correct
+  integer, together with agreement close enough that all seven implementations select the same one.
+
+#v(0.5em)
+*The earlier approximation*
+
+The function was previously ACM Algorithm 209 (@ibbetson1963), contributed by Ibbetson in 1963 and
+  built on polynomial approximations credited in the published note to A. M. Murray of Aberdeen
+  University.
+That approximation is short and requires no library calls, which is why it was chosen.
+
+Its accuracy was assessed twice in print soon after publication (@pike1964, @hill1967), the second
+  time alongside six other algorithms for the same function.
+Measured here against a reference accurate to 36 digits, its worst relative error reaches
+  $4.5 dot 10^(-7)$ near the center, where the margins spend most of their evaluations.
+That gap reaches the returned value rather than remaining beneath it.
+Recomputing the margins over the Edgeworth region with an accurate distribution function changes
+  13 of 2961 of them, so on roughly $0.4%$ of those inputs all seven implementations agreed on an
+  integer that was not the correct one.
+
+Agreement across implementations does not imply accuracy.
+A shared approximation moves all seven the same way, so comparing them against each other cannot
+  detect an error inside the approximation itself; only a reference can.
+
+#v(0.5em)
+*What replaced it*
+
+The construction described in the algorithm section reaches a worst relative error of
+  $9.1 dot 10^(-15)$ over $abs(z) <= 6$, closer by a factor of $5 dot 10^7$ over the central region.
+Both approximations stop somewhere in the tail and return exactly zero beyond it, the older one at
+  $abs(z) = 6$ and this one at $abs(z) = 6.08$; the difference between them is accuracy across the
+  range the estimators use, not the presence or absence of a cutoff.
+
+The 13 margins it changes are byte-identical to those produced by an independent implementation of
+  the complementary error function taken from a platform library.
+Two implementations sharing no coefficients and no structure, agreeing on which 13 margins change
+  and on what each changes to, establishes the result in a way that comparing the new function
+  against its own reference cannot: that comparison would show only that the fit converged.
+
+#v(0.5em)
+*The cost of accuracy in the tail*
+
+Reproducing the tail requires an exponential, and the earlier approximation avoided one precisely
+  because it required no library calls at all.
+Introducing the exponential introduces a dependency on a function IEEE 754 leaves unspecified,
+  which is the subject of the #link(<sec-exp-function>)[$ExpFunction$] section and the reason that
+  section exists.
+
+The tail regime is not what introduces that dependency.
+The density term beside the distribution function in both expansions is itself an exponential, so
+  the path from sample to order statistic passes through a library call either way.
+#link(<sec-conformance-classes>)[Conformance Classes] describes how that path is measured.
+
+#v(0.5em)
+*What the construction deliberately omits*
+
+The function is not correctly rounded, and no attempt is made to make it so.
+Correct rounding would require carrying extended precision through both polynomial chains in seven
+  languages, two of which provide no inexpensive way to do it.
+
+The accuracy delivered clears the requirement by a wide margin.
+The quantity being approximated is itself an approximation to a discrete distribution, and the
+  truncation error of the Edgeworth expansion exceeds $9.1 dot 10^(-15)$ by orders of magnitude.
+Accuracy beyond that point improves no answer the toolkit returns.

--- a/manual/additive-cumulative/additive-cumulative-references.typ
+++ b/manual/additive-cumulative/additive-cumulative-references.typ
@@ -1,0 +1,7 @@
+#list(marker: none, tight: true,
+  cite(<ibbetson1963>, form: "full"),
+  cite(<pike1964>, form: "full"),
+  cite(<hill1967>, form: "full"),
+  cite(<cody1969>, form: "full"),
+  cite(<trefethen2019>, form: "full"),
+)

--- a/manual/additive-cumulative/additive-cumulative-tests.typ
+++ b/manual/additive-cumulative/additive-cumulative-tests.typ
@@ -1,0 +1,36 @@
+#import "/manual/definitions.typ": *
+
+$ AdditiveCumulative(z) $
+
+The function has no shared fixture directory of its own.
+Three arrangements cover it instead, each reaching a property the others do not.
+
+*Through the margins*.
+Every fixture of #link(<sec-pairwise-margin>)[$PairwiseMargin$] and
+  #link(<sec-signed-rank-margin>)[$SignedRankMargin$] whose sample size exceeds the
+  exact-computation limit evaluates this function, and those fixtures compare by binary64 payload
+  rather than by tolerance.
+This is the coverage that matters most, because it exercises the function at the values the
+  estimators actually reach, including the fixtures placed exactly on an Edgeworth decision
+  boundary where the returned integer changes between one representable misrate and the next.
+
+*Against a reference*.
+A fixture of 999 quantiles of the standard $Additive$ distribution records the values the generating
+  implementation produces, which pins the approximation itself rather than its effect on a margin.
+This fixture is read by the generating implementation alone, so it constrains that one rather than
+  the agreement between the seven.
+
+*Under perturbation*.
+The conformance experiment described in the methodology chapter recomputes every estimator with
+  each library call returning the neighboring representable value, and requires the margins that
+  depend on this function not to move.
+The only library call remaining on that path is an exponential the toolkit supplies itself, so the
+  requirement holds by construction rather than by measurement.
+
+A separate suite of arguments in isolation was considered and not built.
+Such a suite would pin the function at points no estimator visits while adding nothing at the
+  points they do, and a fixture the code never reaches is a maintenance cost rather than a
+  guarantee.
+The exponential beneath it is a different case and does have its own suite, described in
+  #link(<sec-exp-function>)[$ExpFunction$], because that is the layer where the seven
+  implementations could disagree.

--- a/manual/additive-cumulative/additive-cumulative.typ
+++ b/manual/additive-cumulative/additive-cumulative.typ
@@ -1,0 +1,83 @@
+#import "/manual/definitions.typ": *
+
+== AdditiveCumulative <sec-additive-cumulative>
+
+$ AdditiveCumulative(z) $
+
+The distribution function of the standard $Additive$ ('Normal') distribution.
+
+#v(0.3em)
+*Input*
+
+#list(marker: none, tight: true,
+  [$z in (-oo, +oo)$ --- a standardized deviation, in units of spread from the center],
+)
+
+#v(0.3em)
+*Output*
+
+#list(marker: none, tight: true,
+  [*Value* --- the share of a standard $Additive$ distribution at or below $z$],
+  [*Unit* --- probability, in $[0, 1]$],
+)
+
+#v(0.3em)
+*Notes*
+
+#list(marker: none, tight: true,
+  [*Purpose* --- supplies the leading term of the Edgeworth expansions used by both margins],
+  [*Used by* --- #link(<sec-pairwise-margin>)[$PairwiseMargin$] and
+    #link(<sec-signed-rank-margin>)[$SignedRankMargin$] above their exact-computation limits],
+  [*Built from* --- two polynomial chains and #link(<sec-exp-function>)[$ExpFunction$]],
+  [*Accuracy* --- worst relative error $9.1 dot 10^(-15)$ over $abs(z) <= 6$],
+  [*Note* --- evaluated identically by all seven implementations, to the last bit],
+)
+
+#v(0.5em)
+*Properties*
+
+#list(marker: none, tight: true,
+  [*Reflection* #h(2em) $AdditiveCumulative(-z) = 1 - AdditiveCumulative(z)$],
+  [*Bounds* #h(2em) $0 <= AdditiveCumulative(z) <= 1$],
+  [*Monotonicity* #h(2em) non-decreasing in $z$],
+  [*Center* #h(2em) $AdditiveCumulative(0) = 1 \/ 2$ exactly],
+)
+
+#v(0.3em)
+*Example*
+
+- `AdditiveCumulative(0) = 0.5`
+- `AdditiveCumulative(1) = 0.8413447460685429`
+- `AdditiveCumulative(-1.959963984540054) = 0.025000000000000012`
+
+#v(0.5em)
+This is a supporting function that #link(<sec-pairwise-margin>)[$PairwiseMargin$] and
+  #link(<sec-signed-rank-margin>)[$SignedRankMargin$] use internally, so most users do not need to
+  call it directly.
+No estimator in the toolkit assumes an $Additive$ ('Normal') distribution: the function appears only
+  inside the
+  approximation both margins fall back to once the exact distribution becomes too expensive to
+  compute.
+
+Because the value it returns decides which order statistic a bound reports, its accuracy matters
+  more than that modest role suggests.
+The notes below give the argument.
+
+#pagebreak()
+=== Algorithm <sec-alg-additive-cumulative>
+
+#include "additive-cumulative-algorithm.typ"
+
+#pagebreak()
+=== Notes
+
+#include "additive-cumulative-notes.typ"
+
+#pagebreak()
+=== Tests
+
+#include "additive-cumulative-tests.typ"
+
+=== References
+
+#include "additive-cumulative-references.typ"

--- a/manual/chapters/auxiliary.typ
+++ b/manual/chapters/auxiliary.typ
@@ -18,3 +18,9 @@
 
 #pagebreak()
 #include "../signed-rank-margin/signed-rank-margin.typ"
+
+#pagebreak()
+#include "../additive-cumulative/additive-cumulative.typ"
+
+#pagebreak()
+#include "../exp-function/exp-function.typ"

--- a/manual/exp-function/exp-function-algorithm.typ
+++ b/manual/exp-function/exp-function-algorithm.typ
@@ -1,0 +1,82 @@
+#import "/manual/definitions.typ": *
+
+The $ExpFunction$ function evaluates $e^y$ using only operations whose results IEEE 754 fixes, so
+  that seven independent implementations produce identical bits.
+
+The construction is the classical range reduction.
+Writing $y$ as a multiple of $ln 2$ plus a small remainder turns the exponential into a power of
+  two, which is exact, multiplied by an exponential of a small argument, which a polynomial
+  reproduces well:
+
+$ k = floor(y \/ (ln 2) + 1 \/ 2), quad r = y - k ln 2, quad e^y = 2^k dot e^r $
+
+with $abs(r) <= (ln 2) \/ 2 approx 0.347$.
+Four decisions within that outline determine whether the result is reproducible, and each is
+  described below.
+
+*The rounding is written out rather than named*
+
+$k$ is computed as $floor(y \/ (ln 2) + 1 \/ 2)$ rather than by calling a rounding function.
+Languages disagree about what rounding means: some round halves away from zero, others round them
+  to even.
+Naming a rounding would therefore name a disagreement, while the floor behaves identically
+  everywhere.
+
+*$ln 2$ is split so that the subtraction stays exact*
+
+$ln 2$ is stored as two doubles: a high part $L_"hi"$ carrying 32 significant bits, and a low
+  remainder $L_"lo"$ holding what the first one drops.
+The technique is due to Cody and Waite (@codywaite1980) and is standard in libraries that evaluate
+  elementary functions (@muller2016).
+The reduction then proceeds in two named halves:
+
+$ "hi" = y - k L_"hi", quad "lo" = k L_"lo", quad r = "hi" - "lo" $
+
+Since $abs(k)$ never exceeds 11 bits, the product $k L_"hi"$ needs at most $32 + 11 = 43$ of the 53
+  bits available and is therefore exact, which makes $"hi"$ exact as well.
+Computing $y - k ln 2$ in a single step would instead subtract two nearby numbers and lose the low
+  bits of $r$, which is where the accuracy of the result resides.
+
+*The polynomial fits a correction rather than the function*
+
+The quantity approximated is not $e^r$ but
+
+$ Q(r) = (e^r - 1 - r) \/ r^2 $
+
+evaluated as a chain of 12 coefficients by Horner's method.
+The two leading terms then carry no fitting error at all, and the polynomial supplies only a
+  correction whose magnitude never exceeds $0.07$.
+The coefficients come out as the Taylor series $1\/2, 1\/6, 1\/24, dots$, which a reader can verify
+  by inspection.
+
+*The two halves of the reduction are kept apart until the end*
+
+The result is assembled from $"hi"$ and $"lo"$ rather than from $r$:
+
+$ p = 1 - (("lo" - r^2 Q(r)) - "hi") $
+
+In exact arithmetic this equals $1 + r + r^2 Q(r)$, since $r = "hi" - "lo"$.
+The two differ in binary64 because $r$ reaches $0.347$, so adding it to $1$ shifts the mantissa two
+  places and the low bits fall off the end.
+Reconstructing the sum from the two halves preserves them: $"hi"$ is exact, and only the correction
+  term $r^2 Q(r)$ is exposed to the rounded $r$.
+
+This single line accounts for most of the accuracy the function achieves.
+Measured against a sixty-digit reference, it reduces the worst relative error from
+  $2.19 dot 10^(-16)$ to $1.30 dot 10^(-16)$ and raises the share of correctly rounded results from
+  $72.6%$ to $90.0%$, at no cost: the same operations in a different order.
+
+*The scaling proceeds in two steps*
+
+$ e^y = (p dot 2^j) dot 2^(k - j), quad j = "trunc"(k \/ 2) $
+
+Applying $2^k$ in one step would require constructing $2^(-1075)$ at the bottom of the range, which
+  is not a representable number.
+Splitting the exponent keeps the first factor within the normal range for every $k$, so only the
+  second factor can denormalize or overflow, and it does so in a single rounding.
+
+Obtaining $2^n$ exactly is the one place where the seven implementations differ in wording rather
+  than in meaning.
+Some languages provide a scaling primitive, some construct the exponent field directly, and two
+  provide neither and use exponentiation guarded by a test that it is exact across the whole range
+  the reduction can reach.

--- a/manual/exp-function/exp-function-notes.typ
+++ b/manual/exp-function/exp-function-notes.typ
@@ -1,0 +1,164 @@
+#import "/manual/definitions.typ": *
+
+*Why the toolkit supplies its own exponential*
+
+IEEE 754 fixes the result of every arithmetic operation and of the square root (@ieee2019).
+For the exponential and the other transcendental functions the standard recommends correct
+  rounding rather than requiring it, which leaves conforming implementations free to differ.
+Two libraries can both satisfy the standard and still return neighboring values for the same
+  argument, and the standard offers no way to prefer one over the other.
+
+For most numerical work this freedom costs nothing, since a last-bit difference in an exponential
+  propagates into a last-bit difference in the answer.
+The margins are not such a case.
+Each of them compares the value against a misrate, the comparison decides an integer index, and
+  that index selects an order statistic out of the sorted sample.
+A one-bit difference either changes nothing or changes which observation is reported, and the gap
+  between adjacent observations is set by the data rather than by the arithmetic.
+
+The effect appears on inputs that sit exactly on a decision boundary.
+On one such input the margin evaluates to $2830$ under two of the seven implementations and to
+  $2832$ under the remaining five.
+Every intermediate quantity agrees to the last bit until the distribution function, where two
+  implementations differ by one unit in the last place.
+The split follows which exponential each language runtime calls, and nothing about the statistics.
+
+#v(0.5em)
+*What each language would otherwise call*
+
+Seven languages do not mean seven exponentials.
+Four of them reach the same system library, two descend from a single 1993 source, and one carries
+  its own implementation, so the ports fall into three groups rather than seven.
+On the crossover described above, the four system-library ports and Kotlin returned $2832$ while
+  TypeScript and Go returned $2830$, which is the three groups resolving into two answers.
+
+#table(
+  columns: 3,
+  align: (left, left, left),
+  stroke: none,
+  table.hline(),
+  [*Language*], [*Exponential it would call*], [*Consequence*],
+  table.hline(),
+  [C\#], [System library through the runtime], [Identical to Python, R, Rust],
+  [Python], [System library through `math.exp`], [Identical to C\#, R, Rust],
+  [R], [System library through `exp`], [Identical to C\#, Python, Rust],
+  [Rust], [System library through `f64::exp`], [Identical to C\#, Python, R],
+  [Kotlin], [Vendor library, or fdlibm by architecture], [Differs from itself across machines],
+  [TypeScript], [fdlibm, until the runtime replaced it], [Differs from the four above],
+  [Go], [Its own implementation, in Go], [Differs from every other port],
+  table.hline(),
+)
+
+Measured over 200001 arguments in the band these estimators reach, the four system-library ports
+  agree with each other on every argument, and the 1993 lineage agrees with itself on every
+  argument.
+Between those two groups the results differ on $10.0%$ of arguments, and the Go implementation
+  differs from the system library on $13.6%$ and from the 1993 lineage on $16.1%$.
+Every disagreement is one unit in the last place, or two where Go is involved.
+
+Three properties of this landscape each defeat a plausible alternative to writing the function.
+
+Naming one implementation does not narrow the target.
+The four ports that share a system library do agree exactly, yet that library ships one algorithm
+  compiled twice, with and without fused multiply-add, and selects between the two at load time
+  according to processor features.
+The variants disagree on $0.06%$ of arguments within a single installation, so even "the system
+  library on this machine" names two functions rather than one.
+
+A managed runtime is not one implementation either.
+The Kotlin port's exponential substitutes a vendor routine on one processor architecture and falls
+  back to the runtime's own copy of the 1993 reference code on another, so the same program returns
+  different bits on different machines.
+Its two exponentials, both reachable from the same program, disagree on $9.9%$ of arguments.
+
+Pinning a version does not hold the target still.
+The TypeScript runtime replaced its exponential outright during the preparation of this manual,
+  moving from the 1993 lineage to a correctly rounded implementation, so the port's results would
+  have changed with an upgrade that no line of this toolkit requested.
+
+#v(0.5em)
+*Accuracy relative to the alternatives*
+
+Writing a function does not make it better than the ones written by specialists.
+Each row below reports the worst relative error over the band these estimators reach, measured
+  against a sixty-digit reference, together with the share of arguments where the result is the
+  correctly rounded double.
+
+#table(
+  columns: 3,
+  align: (left, right, right),
+  stroke: none,
+  table.hline(),
+  [*Implementation*], [*Worst relative error*], [*Correctly rounded*],
+  table.hline(),
+  [Table-based system library], [$1.11 dot 10^(-16)$], [$99.9%$],
+  [Table-based vendor library], [$1.11 dot 10^(-16)$], [$99.7%$],
+  [$ExpFunction$], [$1.30 dot 10^(-16)$], [$90.0%$],
+  [1993 reference code], [$1.30 dot 10^(-16)$], [$90.0%$],
+  [One language runtime], [$2.55 dot 10^(-16)$], [$86.4%$],
+  table.hline(),
+)
+
+The function places third of five, matching the long-standing reference implementation that two of
+  the runtimes descend from and exceeding one of the runtimes it replaces.
+
+Two qualifications bound what those figures mean.
+The tabulated errors are maxima over a uniform grid; searching the same range adversarially raises
+  this function's worst relative error to $1.37 dot 10^(-16)$, and the same search would raise the
+  other rows similarly.
+More importantly, relative error stops describing anything once the result becomes subnormal, below
+  about $y = -708$: there the correctly rounded result itself carries a relative error approaching
+  $1$, because binary64 has no bits left to carry it.
+The margins reach that region whenever the standardized statistic exceeds $37.6$ in magnitude, at
+  which point the density term is $10^(-308)$ and contributes nothing to the sum it enters.
+
+The bound that does hold everywhere is stated in units of the last place rather than as a ratio.
+Every implementation in the table, this one included, returns one of the two doubles bracketing the
+  true value, so the entire spread across the five spans a single bit.
+For this construction the bound follows from the arithmetic rather than from sampling: the scaling
+  step is exact for every reachable exponent, so the only rounding after the polynomial assembly is
+  the final subtraction, whose measured envelope stays below half an ulp.
+
+What this construction offers is not accuracy but agreement: it lies within one bit of every
+  alternative and returns identical bits in all seven languages.
+An estimator that returns the most accurate of seven different observations serves the reader
+  worse than one that returns the same observation everywhere.
+
+#v(0.5em)
+*Constructions considered and set aside*
+
+The 1993 reference code (@ng1993) reaches its accuracy through the rational form
+  $1 + r + r R \/ (2 - R)$,
+  which compensates for a polynomial of lower degree.
+Applied on top of the degree-11 chain used here, the division changes no measured quantity, so the
+  simpler form is kept.
+
+Library implementations written since 2018 add a table of 128 entries, which reduces the argument
+  by a further factor of $128$ and reaches the $99.9%$ row above.
+That construction requires 263 constants where this one requires 15, transcribed into seven
+  languages, with each transcription an opportunity to mistype a digit.
+Two prototypes of it built during this work produced errors an order of magnitude larger than the
+  polynomial they were meant to improve.
+A function reimplemented seven times should be one that is difficult to get wrong, which the
+  table is not.
+
+A correctly rounded implementation would deliver identical results and half-an-ulp accuracy
+  together, and is the strongest alternative.
+Reaching it requires evaluating at progressively higher precision until the rounding is decided
+  (@ziv1991), which is why such implementations carry a multi-precision fallback path.
+It requires either fused multiply-add or emulated extended precision in every language, and two of
+  the seven provide neither cheaply, which is a substantial cost for a value whose purpose is to be
+  compared against a misrate.
+
+#v(0.5em)
+*Precedent*
+
+Software that requires identical results across platforms arrives at this solution regularly.
+Java specifies its $"StrictMath"$ exponential by naming the 1993 implementation that it must
+  reproduce (@oracle2025), which makes the algorithm rather than the accuracy the published
+  contract.
+A game studio documented the same conclusion in 2014 after recorded sessions failed to replay on
+  another operating system, and reported that the difficulty was never precision but obtaining the
+  same, possibly imprecise, outcome everywhere.
+Other projects avoid the question entirely by running their simulations in fixed-point arithmetic
+  with tabulated transcendental functions.

--- a/manual/exp-function/exp-function-references.typ
+++ b/manual/exp-function/exp-function-references.typ
@@ -1,0 +1,8 @@
+#list(marker: none, tight: true,
+  cite(<codywaite1980>, form: "full"),
+  cite(<ng1993>, form: "full"),
+  cite(<ziv1991>, form: "full"),
+  cite(<muller2016>, form: "full"),
+  cite(<ieee2019>, form: "full"),
+  cite(<oracle2025>, form: "full"),
+)

--- a/manual/exp-function/exp-function-tests.typ
+++ b/manual/exp-function/exp-function-tests.typ
@@ -1,0 +1,64 @@
+#import "/manual/definitions.typ": *
+
+$ ExpFunction(y) $
+
+The $ExpFunction$ test suite contains 4 test cases holding 1032 arguments in total
+  (401 working band + 201 Edgeworth band + 401 finite range + 29 boundaries).
+All seven implementations compare the results by binary64 payload rather than by tolerance, since
+  a tolerance would accept precisely the divergence this suite exists to detect.
+
+*Working band* — 401 points over $[-18.5, 0]$:
+
+- The interval $e^(-t^2)$ reaches for the $t in [1\/2, 4.3]$ that
+  #link(<sec-additive-cumulative>)[$AdditiveCumulative$] uses in its tail regime.
+
+*Edgeworth band* — 201 points over $[-40, 0]$:
+
+- Covers the density term of both margins' expansions.
+
+*Finite range* — 401 points over $[-745, 709]$:
+
+- Spans the largest finite result down through the subnormal range to the smallest denormal.
+
+*Boundaries* — 29 points at the values where the construction changes behavior:
+
+- The reduction endpoints at $plus.minus (ln 2) \/ 2$ and $plus.minus 3 (ln 2) \/ 2$
+- The underflow cutoff with its neighbors on both sides
+- The first denormals, and both signed zeros
+
+Arguments above $709.78$ are absent because their result is infinite and JSON provides no way to
+  express one.
+Each implementation keeps its own unit test for the overflow cutoff, where a language can name its
+  infinity.
+
+*Why this suite exists separately*
+
+Every other suite reaches this function through a margin, which exercises it wherever an Edgeworth
+  expansion happens to look and nowhere else.
+That leaves the one function on the decision path that IEEE 754 does not fix without direct
+  coverage.
+
+Expected values transcribed by hand from another implementation would not serve: such a copy goes
+  stale without announcing itself whenever the function changes.
+The fixture is generated alongside the others, and the build regenerates it and requires a
+  byte-identical result, so it cannot drift from the code that produces it.
+
+*Properties checked beyond the payloads*
+
+*Exactness of the scaling primitive*.
+The two implementations that lack a scaling function use exponentiation, whose exactness is a
+  property of the platform rather than of the language.
+Both compare it against a construction that cannot be wrong, across every exponent the reduction
+  can reach, deriving that range from the cutoffs so that widening a cutoff widens the test.
+
+*Monotonicity*.
+Both margins binary-search an expansion under the assumption that it is monotone in the index,
+  which rests on this function being monotone.
+A single inversion would allow the search to return either neighbor.
+No inversion has been found.
+
+*That the fixture is actually compared*.
+A fixture loader that finds no files reports success.
+Each of the seven pins the argument count, and each was checked by breaking a scratch copy of the
+  fixture and confirming the suite fails: a one-unit change in each file, a deleted file, and a
+  truncated argument list.

--- a/manual/exp-function/exp-function.typ
+++ b/manual/exp-function/exp-function.typ
@@ -1,0 +1,81 @@
+#import "/manual/definitions.typ": *
+
+== ExpFunction <sec-exp-function>
+
+$ ExpFunction(y) $
+
+The exponential function, supplied by the toolkit rather than by the platform.
+
+#v(0.3em)
+*Input*
+
+#list(marker: none, tight: true,
+  [$y in (-oo, +oo)$ --- a point on the real line],
+)
+
+#v(0.3em)
+*Output*
+
+#list(marker: none, tight: true,
+  [*Value* --- $e^y$],
+  [*Unit* --- dimensionless],
+)
+
+#v(0.3em)
+*Notes*
+
+#list(marker: none, tight: true,
+  [*Purpose* --- removes the last library call from the path that decides an order statistic],
+  [*Used by* --- #link(<sec-additive-cumulative>)[$AdditiveCumulative$] in its tail regime, and the density term of
+    both margins' Edgeworth expansions],
+  [*Built from* --- a range reduction and one polynomial, using only operations IEEE 754 pins],
+  [*Accuracy* --- never more than one unit in the last place from the correctly rounded result;
+    worst relative error $1.4 dot 10^(-16)$ under a search of the range where the result is normal],
+  [*Note* --- all seven implementations return identical bits on every argument],
+)
+
+#v(0.5em)
+*Properties*
+
+#list(marker: none, tight: true,
+  [*Monotonicity* #h(2em) non-decreasing in $y$, with no inversions on any tested band],
+  [*Positivity* #h(2em) $ExpFunction(y) > 0$ for every $y$ above the underflow cutoff],
+  [*Identity* #h(2em) $ExpFunction(0) = 1$ exactly],
+  [*Cutoffs* #h(2em) $+oo$ above $y = 709.79$, zero below $y = -745.2$, NaN preserved],
+)
+
+#v(0.3em)
+*Example*
+
+- `ExpFunction(0) = 1`
+- `ExpFunction(1) = 2.7182818284590455`
+- `ExpFunction(-18.5) = 9.237449661970594e-09`
+
+#v(0.5em)
+A statistical toolkit does not normally supply its own exponential.
+This one does because IEEE 754 fixes the result of every arithmetic operation and of the square
+  root while fixing nothing about the exponential, so two conforming libraries may return
+  neighboring values for the same argument.
+
+That freedom is ordinarily harmless.
+Here the value is compared against a misrate and the comparison selects an order statistic, so a
+  last-bit difference produces a different confidence interval from identical inputs.
+
+#pagebreak()
+=== Algorithm <sec-alg-exp-function>
+
+#include "exp-function-algorithm.typ"
+
+#pagebreak()
+=== Notes
+
+#include "exp-function-notes.typ"
+
+#pagebreak()
+=== Tests
+
+#include "exp-function-tests.typ"
+
+=== References
+
+#include "exp-function-references.typ"

--- a/manual/methodology/methodology.typ
+++ b/manual/methodology/methodology.typ
@@ -492,11 +492,12 @@ The two were in tension in one place, and resolving it turned out to require ans
   question the classes above had never been asked.
 
 #v(0.3em)
-The normal distribution function inside the Edgeworth branches of both margins used to be ACM
+The $Additive$ ('Normal') distribution function inside the Edgeworth branches of both margins
+  used to be ACM
   Algorithm 209, a polynomial evaluated identically by all seven.
 It was chosen for being identical, not for being close, and it was not close: measured against a
   reference good to thirty-six digits, its worst relative error is $4.5 dot 10^(-7)$ near the
-  center, and past $abs(x) = 6$ it returns exactly zero, a relative error of $1$.
+  center, and past $abs(z) = 6$ it returns exactly zero, a relative error of $1$.
 That gap reached the answer rather than staying under it.
 Recomputing the margins over the Edgeworth region with an accurate distribution function changes
   13 of 2961 of them, so on about $0.4%$ of those inputs all seven agreed on an integer that was
@@ -505,7 +506,7 @@ Recomputing the margins over the Edgeworth region with an accurate distribution 
 #v(0.3em)
 It is now a pair of Chebyshev-fitted polynomial chains whose coefficients are produced from that
   reference rather than transcribed from a paper, with a worst relative error of
-  $9.1 dot 10^(-15)$ over $abs(x) <= 6$.
+  $9.1 dot 10^(-15)$ over $abs(z) <= 6$.
 The 13 margins it changes are byte-identical to what an independent implementation of the
   complementary error function produces, which is the confirmation that matters: two
   implementations sharing no coefficients agree on exactly the same set.
@@ -517,8 +518,8 @@ IEEE 754 fixes the result of every arithmetic operation and of the square root, 
 Two implementations returning neighboring values is normally harmless, but here the value is
   compared against a misrate and the comparison selects an order statistic, so a last-bit
   difference becomes a different confidence interval from identical inputs.
-It did: on one Edgeworth crossover the margin came out 2830 under two implementations of the
-  exponential and 2832 under the other four.
+It did: on one Edgeworth crossover the margin came out 2830 under two of the seven ports and
+  2832 under the remaining five, split by which exponential each language runtime calls.
 
 #v(0.3em)
 The instrument had reported none of this, because it had been sweeping the wrong boundary.
@@ -544,7 +545,7 @@ With it the sweep reports zero movement on every estimator declared exact, inclu
 What that costs in accuracy is worth stating plainly, because owning a function does not make it
   better than the ones written by people who do it for a living.
 Measured against a sixty-digit reference over the range these estimators reach, it has a worst
-  relative error of $1.2 dot 10^(-16)$ and returns the correctly rounded result on 90% of inputs.
+  relative error of $1.3 dot 10^(-16)$ and returns the correctly rounded result on 90% of inputs.
 The best platform libraries are better, at $1.1 dot 10^(-16)$ and 99.9%.
 No implementation measured here, the toolkit's included, is ever more than one unit in the last
   place from the correctly rounded value, so the whole spread is one bit wide.

--- a/manual/references.yaml
+++ b/manual/references.yaml
@@ -284,3 +284,155 @@ boxmuller1958:
   page-range: 610-611
   doi: 10.1214/aoms/1177706645
   url: https://projecteuclid.org/euclid.aoms/1177706645
+
+ibbetson1963:
+  type: article
+  title: "Algorithm 209: Gauss"
+  author:
+    - name: Ibbetson
+      given-name: D.
+  date: 1963-10
+  parent:
+    - type: periodical
+      title: Communications of the ACM
+      volume: 6
+      issue: 10
+  page-range: 616
+  doi: 10.1145/367651.367664
+  url: https://doi.org/10.1145/367651.367664
+
+pike1964:
+  type: article
+  title: "Certification of Algorithm 209: Gauss"
+  author:
+    - name: Pike
+      given-name: M. C.
+  date: 1964-08
+  parent:
+    - type: periodical
+      title: Communications of the ACM
+      volume: 7
+      issue: 8
+  page-range: 482
+  doi: 10.1145/355586.364808
+  url: https://doi.org/10.1145/355586.364808
+
+hill1967:
+  type: article
+  title: "Remarks on Algorithm 209: Gauss"
+  author:
+    - name: Hill
+      given-name: I. D.
+    - name: Joyce
+      given-name: S. A.
+  date: 1967-06
+  parent:
+    - type: periodical
+      title: Communications of the ACM
+      volume: 10
+      issue: 6
+  page-range: 377
+  doi: 10.1145/363332.365435
+  url: https://doi.org/10.1145/363332.365435
+
+cody1969:
+  type: article
+  title: Rational Chebyshev Approximations for the Error Function
+  author:
+    - name: Cody
+      given-name: W. J.
+  date: 1969
+  parent:
+    - type: periodical
+      title: Mathematics of Computation
+      volume: 23
+      issue: 107
+  page-range: 631-637
+  doi: 10.1090/S0025-5718-1969-0247736-4
+  url: https://doi.org/10.1090/S0025-5718-1969-0247736-4
+
+codywaite1980:
+  type: book
+  title: "Software Manual for the Elementary Functions"
+  author:
+    - name: Cody
+      given-name: William J.
+      suffix: Jr.
+    - name: Waite
+      given-name: William
+  date: 1980
+  publisher: Prentice-Hall
+  location: Englewood Cliffs, New Jersey
+  isbn: 9780138220648
+
+ziv1991:
+  type: article
+  title: "Fast evaluation of elementary mathematical functions with correctly rounded last bit"
+  author:
+    - name: Ziv
+      given-name: Abraham
+  date: 1991
+  parent:
+    - type: periodical
+      title: ACM Transactions on Mathematical Software
+      volume: 17
+      issue: 3
+  page-range: 410-423
+  doi: 10.1145/114697.116813
+  url: https://doi.org/10.1145/114697.116813
+
+ng1993:
+  type: repository
+  title: "FDLIBM: Freely Distributable Math Library"
+  author:
+    - name: Ng
+      given-name: K. C.
+  date: 1993
+  organization: Sun Microsystems
+  serial-number: Version 5.3
+  url: https://www.netlib.org/fdlibm/
+
+muller2016:
+  type: book
+  title: "Elementary Functions: Algorithms and Implementation"
+  author:
+    - name: Muller
+      given-name: Jean-Michel
+  date: 2016
+  edition: 3
+  publisher: Birkhäuser Boston
+  isbn: 9781489979810
+  doi: 10.1007/978-1-4899-7983-4
+  url: https://doi.org/10.1007/978-1-4899-7983-4
+
+ieee2019:
+  type: report
+  title: "IEEE Standard for Floating-Point Arithmetic"
+  author:
+    - name: IEEE
+  date: 2019
+  organization: IEEE
+  serial-number: IEEE Std 754-2019
+  doi: 10.1109/IEEESTD.2019.8766229
+  url: https://doi.org/10.1109/IEEESTD.2019.8766229
+
+trefethen2019:
+  type: book
+  title: "Approximation Theory and Approximation Practice, Extended Edition"
+  author:
+    - name: Trefethen
+      given-name: Lloyd N.
+  date: 2019
+  publisher: Society for Industrial and Applied Mathematics
+  location: Philadelphia
+  isbn: 9781611975932
+  doi: 10.1137/1.9781611975949
+  url: https://doi.org/10.1137/1.9781611975949
+
+oracle2025:
+  type: web
+  title: "StrictMath (Java SE 25 & JDK 25 API Specification)"
+  author:
+    - name: Oracle
+  date: 2025
+  url: https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/lang/StrictMath.html

--- a/py/AGENTS.md
+++ b/py/AGENTS.md
@@ -30,8 +30,8 @@ py/
 │   ├── signed_rank_margin.py      # Signed-rank margin computation
 │   ├── min_misrate.py             # Minimum achievable misrate calculation
 │   ├── _binomial.py               # Binomial coefficient shared by the two above (internal)
-│   ├── gauss_cdf.py               # Standard normal CDF (Chebyshev-fitted erf/erfc)
-│   ├── portable_exp.py            # Reproducible exp: range reduction plus fitted polynomial
+│   ├── additive_cumulative.py            # Standard normal CDF (Chebyshev-fitted erf/erfc)
+│   ├── exp_function.py            # Reproducible exp: range reduction plus fitted polynomial
 │   ├── rng.py                     # Deterministic xoshiro256++ PRNG
 │   ├── xoshiro256.py              # PRNG core implementation
 │   ├── center_impl.py             # O(n log n) Hodges-Lehmann algorithm
@@ -46,6 +46,7 @@ py/
 │   ├── test_binary64.py           # Covers the exactness predicates themselves
 │   ├── test_invariance.py         # Mathematical property tests
 │   ├── test_mutation.py           # Raw-API input-mutation safety
+│   ├── test_negative_zero.py      # No estimator reports a -0.0 (payload-level)
 │   ├── test_pairwise_margin_consistency.py  # Binomial regressions behind the pairwise margin
 │   ├── test_performance.py        # Performance smoke test
 │   ├── test_reference.py          # JSON fixture validation (includes sample-construction, unit-propagation)
@@ -117,6 +118,16 @@ take original-order values plus optional pre-sorted views (`sorted_view` /
 `sorted_x` / `sorted_y`) used only for the order-independent sub-computations;
 the `Sample` path passes `values` together with the cached `sorted_values`.
 
+## Signed Zeros
+
+No estimator reports a `-0.0`. A sample holding both `+0.0` and `-0.0` would
+otherwise make the result depend on which of the two the sort left in the
+selected position, which is a property of the sorting algorithm rather than of
+the data, and the seven ports each bring their own sort. The scalar `_*_raw`
+helpers return through `_normalize_zero`, and every `Bounds` is built by
+`_new_bounds`, which normalizes both endpoints. Only outputs are normalized: a
+sample may still contain `-0.0`, and infinities pass through untouched.
+
 ## Unit Propagation Rules
 
 | Estimator | Output Unit |
@@ -156,6 +167,9 @@ Weighted samples are rejected by all estimators.
   doubles are identical". It compares the raw binary64 payloads, never `==` (which
   passes `-0.0` against `+0.0` and fails a pair of identical NaNs), and every
   failure prints both payloads in hex next to the decimal values.
+- **Signed zeros**: `tests/test_negative_zero.py` pins the no-`-0.0` output
+  invariant by payload, since `-0.0 == 0.0` makes an equality assertion pass on
+  exactly the results it exists to reject.
 - **Tolerance**: `1e-9`, for the genuinely approximate suites only (ratio,
   ratio-bounds, compare2, the transcendental distributions, invariance)
 

--- a/py/pragmastat/additive_cumulative.py
+++ b/py/pragmastat/additive_cumulative.py
@@ -24,8 +24,12 @@ def additive_cumulative(z: float) -> float:
         z: a standardized deviation, in units of spread from the center
 
     Returns:
-        Area under the standard normal curve from -infinity to x
+        Area under the standard Additive density from -infinity to z
     """
+    # NaN satisfies neither comparison below, so without this it would leave the tail branch as a
+    # finite 0 or 1 and an undefined input would be answered rather than reported.
+    if math.isnan(z):
+        return z
     t = abs(z) / _SQRT2
     if t < 0.5:
         # erf(t) / t as a polynomial in u = 8 * t^2 - 1

--- a/py/pragmastat/additive_cumulative.py
+++ b/py/pragmastat/additive_cumulative.py
@@ -1,28 +1,37 @@
-package dev.pragmastat
+"""Standard normal CDF.
 
-import kotlin.math.abs
-import kotlin.math.sqrt
+Two Chebyshev-fitted Horner chains and one exponential. The coefficients are produced by
+tests/oracles/fit_additive_cumulative.py against a reference good to 36 digits, so they are
+reproducible rather than transcribed.
 
-/**
- * Computes the standard normal CDF.
- *
- * Two Chebyshev-fitted Horner chains and one exponential. The coefficients are produced by
- * tests/oracles/fit_gauss_cdf.py against a reference good to 36 digits, so they are
- * reproducible rather than transcribed.
- *
- * No rounding pins are needed here: the JVM never contracts a multiply and an add into a fused
- * multiply-add, so every product lands in binary64 on its own, which is what the Go port has to
- * spell out with explicit float64 conversions.
- *
- * @param x Value in range (-infinity, +infinity)
- * @return Area under the Standard Normal Curve from -infinity to x
- */
-internal fun gaussCdf(x: Double): Double {
-    val t = abs(x) / sqrt(2.0)
-    if (t < 0.5) {
-        val s = t * t
-        val u = 8.0 * s - 1.0
-        var p = -1.2757552949301143e-19
+No rounding pins are needed here: Python evaluates every product and every sum as a
+separate binary64 operation and has no multiply-add contraction to disable. Plain floats
+only, since a numpy expression may reassociate.
+"""
+
+import math
+
+from .exp_function import exp_function
+
+_SQRT2 = math.sqrt(2.0)
+
+
+def additive_cumulative(z: float) -> float:
+    """
+    Computes the distribution function of the standard Additive distribution.
+
+    Args:
+        z: a standardized deviation, in units of spread from the center
+
+    Returns:
+        Area under the standard normal curve from -infinity to x
+    """
+    t = abs(z) / _SQRT2
+    if t < 0.5:
+        # erf(t) / t as a polynomial in u = 8 * t^2 - 1
+        s = t * t
+        u = 8.0 * s - 1.0
+        p = -1.2757552949301143e-19
         p = p * u + 1.2307154179828511e-17
         p = p * u - 1.0890239994332592e-15
         p = p * u + 8.774530700097397e-14
@@ -34,14 +43,16 @@ internal fun gaussCdf(x: Double): Double {
         p = p * u + 0.0016130716680617086
         p = p * u - 0.04364205888669792
         p = p * u + 1.0830752376761712
-        val erf = t * p
-        return if (x >= 0.0) 0.5 * (1.0 + erf) else 0.5 * (1.0 - erf)
-    }
+        erf = t * p
+        if z >= 0:
+            return 0.5 * (1.0 + erf)
+        return 0.5 * (1.0 - erf)
 
-    var erfc = 0.0
-    if (t <= 4.3) {
-        val u = (2.0 * t - 4.8) / 3.8
-        var p = 2.403093649825437e-09
+    erfc = 0.0
+    if t <= 4.3:
+        # erfc(t) * exp(t^2) as a polynomial in u = (2 * t - 4.8) / 3.8
+        u = (2.0 * t - 4.8) / 3.8
+        p = 2.403093649825437e-09
         p = p * u - 6.533436159455495e-09
         p = p * u + 1.334437871983186e-09
         p = p * u - 2.5055474016226743e-09
@@ -68,8 +79,8 @@ internal fun gaussCdf(x: Double): Double {
         p = p * u + 0.09925390090168178
         p = p * u - 0.15121195850373031
         p = p * u + 0.21849873453703333
-        erfc = portableExp(-(t * t)) * p
-    }
+        erfc = exp_function(-(t * t)) * p
 
-    return if (x >= 0.0) 1.0 - 0.5 * erfc else 0.5 * erfc
-}
+    if z >= 0:
+        return 1.0 - 0.5 * erfc
+    return 0.5 * erfc

--- a/py/pragmastat/exp_function.py
+++ b/py/pragmastat/exp_function.py
@@ -28,7 +28,7 @@ import math
 
 # Constants of the range reduction, emitted by tests/oracles/fit_exp.py.
 #
-# ln 2 is split so that k*ln2_hi is exact: ln2_hi carries 33 significant bits and |k| needs at
+# ln 2 is split so that k*ln2_hi is exact: ln2_hi carries 32 significant bits and |k| needs at
 # most 11, which leaves the product inside the 53 available. Without the split the reduction
 # would lose the low bits of r, and r is where the accuracy lives.
 _INV_LN2 = 1.4426950408889634e00
@@ -36,7 +36,7 @@ _LN2_HI = 6.9314718036912382e-01
 _LN2_LO = 1.9082149292705877e-10
 
 
-def portable_exp(y: float) -> float:
+def exp_function(y: float) -> float:
     """
     Computes exp(y) identically on every platform.
 

--- a/py/pragmastat/pairwise_margin.py
+++ b/py/pragmastat/pairwise_margin.py
@@ -8,10 +8,10 @@ for small samples (n+m <= 400) and Edgeworth approximation for larger samples.
 import math
 
 from ._binomial import binomial_coefficient as _binomial_coefficient
+from .additive_cumulative import additive_cumulative as _additive_cumulative
 from .assumptions import AssumptionError
-from .gauss_cdf import gauss_cdf as _gauss_cdf
+from .exp_function import exp_function
 from .min_misrate import min_achievable_misrate_two_sample
-from .portable_exp import portable_exp
 
 MAX_EXACT_SIZE = 400
 
@@ -134,8 +134,8 @@ def _edgeworth_cdf(n: int, m: int, u: int) -> float:
     z = (uf - mu - 0.5) / su
 
     # Standard normal PDF and CDF
-    phi = portable_exp((-z * z) / 2.0) / math.sqrt(2.0 * math.pi)
-    big_phi = _gauss_cdf(z)
+    phi = exp_function((-z * z) / 2.0) / math.sqrt(2.0 * math.pi)
+    big_phi = _additive_cumulative(z)
 
     # Pre-compute powers of n and m for efficiency
     n2 = nf * nf

--- a/py/pragmastat/signed_rank_margin.py
+++ b/py/pragmastat/signed_rank_margin.py
@@ -5,10 +5,10 @@ One-sample analog of PairwiseMargin using Wilcoxon signed-rank distribution.
 
 import math
 
+from .additive_cumulative import additive_cumulative
 from .assumptions import AssumptionError
-from .gauss_cdf import gauss_cdf
+from .exp_function import exp_function
 from .min_misrate import min_achievable_misrate_one_sample
-from .portable_exp import portable_exp
 
 # Maximum n for exact computation. Limited to 63 because 2^n must fit in a 64-bit integer.
 SIGNED_RANK_MAX_EXACT_SIZE = 63
@@ -103,8 +103,8 @@ def _signed_rank_edgeworth_cdf(n: int, w: int) -> float:
 
     # +0.5 continuity correction: computing P(W ≤ w) for a left-tail discrete CDF
     z = (float(w) - mu + 0.5) / sigma
-    phi = portable_exp(-z * z / 2.0) / math.sqrt(2.0 * math.pi)
-    big_phi = gauss_cdf(z)
+    phi = exp_function(-z * z / 2.0) / math.sqrt(2.0 * math.pi)
+    big_phi = additive_cumulative(z)
 
     kappa4 = -n_f64 * (n_f64 + 1.0) * (2.0 * n_f64 + 1.0) * (3.0 * n_f64 * n_f64 + 3.0 * n_f64 - 1.0) / 240.0
 

--- a/py/tests/test_additive_cumulative.py
+++ b/py/tests/test_additive_cumulative.py
@@ -1,0 +1,50 @@
+"""``additive_cumulative`` has no answer for a NaN, and must say so rather than inventing one.
+
+Both of the function's range comparisons are false for a NaN, so without an explicit guard it
+leaves the tail branch as a finite 0 or 1: an undefined input answered rather than reported. The
+approximation it replaced propagated NaN, so losing that is a regression on behavior every port
+shares, and it is invisible to the margin fixtures because none of them passes a NaN.
+
+The assertions compare PAYLOADS: ``==`` reads the two zeros as equal and every NaN as unequal,
+and neither reading is the claim being made here.
+"""
+
+import math
+
+import pytest
+from binary64 import assert_identical
+
+from pragmastat.additive_cumulative import additive_cumulative
+
+
+def test_carries_nan_through():
+    assert math.isnan(additive_cumulative(math.nan)), "additive_cumulative(nan) should be nan"
+
+
+@pytest.mark.parametrize(
+    ("z", "expected"),
+    [
+        (math.inf, 1.0),
+        (-math.inf, 0.0),
+        (0.0, 0.5),
+        (-0.0, 0.5),
+    ],
+)
+def test_answers_the_defined_boundaries(z, expected):
+    assert_identical(additive_cumulative(z), expected, f"additive_cumulative({z!r})")
+
+
+def test_exp_function_cutoffs():
+    """The values outside the reduction band, which the shared fixture cannot carry.
+
+    JSON has no way to express an infinity, so the generated suite stops at 709.78 and these
+    arguments are covered here or nowhere.
+    """
+    from pragmastat.exp_function import exp_function
+
+    assert math.isnan(exp_function(math.nan))
+    assert exp_function(709.8) == math.inf
+    assert exp_function(math.inf) == math.inf
+    assert_identical(exp_function(-745.3), 0.0, "exp_function(-745.3)")
+    assert_identical(exp_function(-math.inf), 0.0, "exp_function(-inf)")
+    assert_identical(exp_function(0.0), 1.0, "exp_function(0)")

--- a/py/tests/test_reference.py
+++ b/py/tests/test_reference.py
@@ -39,8 +39,8 @@ from pragmastat.estimators import (
 from pragmastat.estimators import (
     _avg_spread_bounds as avg_spread_bounds,
 )
+from pragmastat.exp_function import exp_function
 from pragmastat.pairwise_margin import pairwise_margin
-from pragmastat.portable_exp import portable_exp
 from pragmastat.signed_rank_margin import signed_rank_margin
 from pragmastat.unit_registry import UnitRegistry
 
@@ -154,13 +154,13 @@ def _load_fixtures(estimator_name):
 # untouched, so any inexactness there would be a wrong element, not a rounding
 # error.
 #
-# The exponential the exact class rests on (portable-exp)
+# The exponential the exact class rests on (exp-function)
 # ------------------------------------------------------
 # The margins reach an exponential, IEEE 754 fixes nothing about one, and a
 # last-bit difference there selects a different order statistic. That is why all
-# seven ports evaluate :func:`pragmastat.portable_exp.portable_exp` instead of the
+# seven ports evaluate :func:`pragmastat.exp_function.exp_function` instead of the
 # platform's. Every other suite reaches that function only through a margin, which
-# samples it wherever an Edgeworth expansion happens to look; portable-exp checks
+# samples it wherever an Edgeworth expansion happens to look; exp-function checks
 # it directly, over the working band, the finite range and the boundaries.
 #
 # JSON is safe to compare against directly: Python's ``json`` module parses a
@@ -730,8 +730,8 @@ class TestReference:
                 f"Failed for test file: {json_file.name}, expected: {expected_output}, got: {actual_output}"
             )
 
-    def test_portable_exp_reference(self):
-        """Test portable_exp against reference data, argument by argument.
+    def test_exp_function_reference(self):
+        """Test exp_function against reference data, argument by argument.
 
         Bitwise, like the manifest declares this suite: a tolerance here would pass
         on exactly the last-bit divergence the fixtures exist to catch (see the
@@ -750,12 +750,12 @@ class TestReference:
           than let the file pass.
         """
         checked = 0
-        for fixture_name, test_case in _load_fixtures("portable-exp"):
+        for fixture_name, test_case in _load_fixtures("exp-function"):
             args = test_case["input"]["arg"]
             expected = test_case["output"]
             # float() only because JSON integer literals (0, 709, -746) arrive as
             # Python ints; every one of them is exactly representable in binary64.
-            actual = [portable_exp(float(arg)) for arg in args]
+            actual = [exp_function(float(arg)) for arg in args]
             assert_sequence_identical(actual, expected, f"Failed for {fixture_name}")
             checked += len(args)
 
@@ -763,7 +763,7 @@ class TestReference:
         # satisfies every assertion above by having nothing to compare. Pinning the
         # total is what makes that visible; raise it deliberately when the generator
         # adds cases.
-        assert checked == 1032, f"portable-exp: compared {checked} arguments, expected 1032"
+        assert checked == 1032, f"exp-function: compared {checked} arguments, expected 1032"
 
     def test_center_bounds_reference(self):
         run_bounds_reference_tests(

--- a/r/AGENTS.md
+++ b/r/AGENTS.md
@@ -22,6 +22,7 @@ r/pragmastat/
 ├── R/
 │   ├── aaa_constants.R          # Internal constants (loaded first)
 │   ├── aa_assumptions.R         # Input validation and error types
+│   ├── normalize_zero.R         # Drops the sign of a negative zero on estimator output
 │   ├── center.R                 # Center estimator
 │   ├── center_bounds.R          # Center confidence bounds
 │   ├── spread.R                 # Spread estimator
@@ -38,8 +39,8 @@ r/pragmastat/
 │   ├── sign_margin.R            # Sign margin for binomial CDF inversion
 │   ├── signed_rank_margin.R     # Signed-rank margin computation
 │   ├── min_misrate.R            # Minimum achievable misrate calculation
-│   ├── gauss_cdf.R              # Standard normal CDF (Chebyshev-fitted erf/erfc)
-│   ├── portable_exp.R           # Reproducible exp: range reduction plus fitted polynomial
+│   ├── additive_cumulative.R           # Standard normal CDF (Chebyshev-fitted erf/erfc)
+│   ├── exp_function.R           # Reproducible exp: range reduction plus fitted polynomial
 │   ├── center_impl.R            # O(n log n) Hodges-Lehmann algorithm
 │   ├── center_quantiles_impl.R  # Center quantile binary search
 │   ├── spread_impl.R            # O(n log n) Shamos algorithm

--- a/r/pragmastat/R/additive_cumulative.R
+++ b/r/pragmastat/R/additive_cumulative.R
@@ -13,7 +13,7 @@
 # returned 34394 against 34396. Both are Edgeworth-branch inputs, and both agree now.
 #
 # The shape is two Chebyshev-fitted Horner chains and one exponential. The coefficients are
-# produced by tests/oracles/fit_gauss_cdf.py against a reference good to 36 digits, so they
+# produced by tests/oracles/fit_additive_cumulative.py against a reference good to 36 digits, so they
 # are reproducible rather than transcribed; the worst relative error over |x| <= 6 is 9.1e-15.
 #
 # The chains are written one product per line to match the other six exactly. Do not
@@ -22,9 +22,9 @@
 # needs pinning here, unlike Go: R evaluates each arithmetic operator on its own and never
 # fuses a multiply into an add.
 
-# gauss_cdf computes P(Z <= x) for a standard normal Z.
-gauss_cdf <- function(x) {
-  t <- abs(x) / sqrt(2)
+# additive_cumulative computes P(Z <= x) for a standard normal Z.
+additive_cumulative <- function(z) {
+  t <- abs(z) / sqrt(2)
   if (t < 0.5) {
     s <- t * t
     u <- 8.0 * s - 1.0
@@ -41,7 +41,7 @@ gauss_cdf <- function(x) {
     p <- p * u - 0.04364205888669792
     p <- p * u + 1.0830752376761712
     erf <- t * p
-    if (x >= 0) {
+    if (z >= 0) {
       return(0.5 * (1.0 + erf))
     }
     return(0.5 * (1.0 - erf))
@@ -77,18 +77,18 @@ gauss_cdf <- function(x) {
     p <- p * u + 0.09925390090168178
     p <- p * u - 0.15121195850373031
     p <- p * u + 0.21849873453703333
-    erfc <- portable_exp(-(t * t)) * p
+    erfc <- exp_function(-(t * t)) * p
   }
 
-  if (x >= 0) {
+  if (z >= 0) {
     return(1.0 - 0.5 * erfc)
   }
   0.5 * erfc
 }
 
-# gauss_pdf computes the standard normal density, spelled as the other six spell it. Both
+# additive_pdf computes the standard normal density, spelled as the other six spell it. Both
 # Edgeworth expansions reach their phi through here, so the two call sites the other ports
 # write out separately are this one line.
-gauss_pdf <- function(z) {
-  portable_exp(-z * z / 2) / sqrt(2 * pi)
+additive_pdf <- function(z) {
+  exp_function(-z * z / 2) / sqrt(2 * pi)
 }

--- a/r/pragmastat/R/additive_cumulative.R
+++ b/r/pragmastat/R/additive_cumulative.R
@@ -24,6 +24,11 @@
 
 # additive_cumulative computes P(Z <= x) for a standard normal Z.
 additive_cumulative <- function(z) {
+  # NaN satisfies neither comparison below; in R the comparison yields NA and the branch errors
+  # instead of returning, so an undefined input has to be answered here.
+  if (is.na(z)) {
+    return(z)
+  }
   t <- abs(z) / sqrt(2)
   if (t < 0.5) {
     s <- t * t

--- a/r/pragmastat/R/exp_function.R
+++ b/r/pragmastat/R/exp_function.R
@@ -24,14 +24,14 @@
 
 # Constants of the range reduction, emitted by tests/oracles/fit_exp.py.
 #
-# ln 2 is split so that k*.LN2_HI is exact: .LN2_HI carries 33 significant bits and |k| needs
+# ln 2 is split so that k*.LN2_HI is exact: .LN2_HI carries 32 significant bits and |k| needs
 # at most 11, which leaves the product inside the 53 available. Without the split the
 # reduction would lose the low bits of r, and r is where the accuracy lives.
 .INV_LN2 <- 1.4426950408889634e+00
 .LN2_HI <- 6.9314718036912382e-01
 .LN2_LO <- 1.9082149292705877e-10
 
-portable_exp <- function(y) {
+exp_function <- function(y) {
   if (is.na(y)) {
     return(y)
   }
@@ -78,7 +78,7 @@ portable_exp <- function(y) {
   # does so in a single rounding.
   #
   # R has no ldexp, so the scalings are spelled 2^n. That is exact for every n reachable
-  # here, which test-portable-exp.R checks against repeated doubling rather than assuming.
+  # here, which test-exp-function.R checks against repeated doubling rather than assuming.
   half <- trunc(k / 2)
   (p * 2^half) * 2^(k - half)
 }

--- a/r/pragmastat/R/pairwise_margin.R
+++ b/r/pragmastat/R/pairwise_margin.R
@@ -129,8 +129,8 @@ edgeworth_cdf <- function(n, m, u) {
   # -0.5 continuity correction: computing P(U >= u) for a right-tail discrete CDF
   z <- (u - mu - 0.5) / su
 
-  phi <- gauss_pdf(z)
-  Phi <- gauss_cdf(z) # Standard normal CDF
+  phi <- additive_pdf(z)
+  Phi <- additive_cumulative(z) # Standard normal CDF
 
   # Pre-compute powers of n and m. Held as doubles from the start, exactly as the other
   # six ports hold them: R integers are 32-bit, and n^4 overflows for n above about 215,

--- a/r/pragmastat/R/signed_rank_margin.R
+++ b/r/pragmastat/R/signed_rank_margin.R
@@ -91,8 +91,8 @@ signed_rank_edgeworth_cdf <- function(n, w) {
 
   # +0.5 continuity correction: computing P(W <= w) for a left-tail discrete CDF
   z <- (w - mu + 0.5) / sigma
-  phi <- gauss_pdf(z)
-  big_phi <- gauss_cdf(z)
+  phi <- additive_pdf(z)
+  big_phi <- additive_cumulative(z)
 
   nf <- as.double(n)
   kappa4 <- -nf * (nf + 1) * (2 * nf + 1) * (3 * nf * nf + 3 * nf - 1) / 240.0

--- a/r/pragmastat/tests/testthat/test-exp-function.R
+++ b/r/pragmastat/tests/testthat/test-exp-function.R
@@ -89,6 +89,16 @@ test_that("exp_function tracks the platform exponential to about 2 ulp", {
   expect_lt(max(abs(actual - expected) / expected), 2^-51)
 })
 
+test_that("additive_cumulative carries NaN through and answers both infinities", {
+  # Both of the function's range comparisons yield NA for a NaN, so without an explicit guard the
+  # branch errors instead of returning. The approximation this replaced propagated NaN.
+  expect_identical(additive_cumulative(NaN), NaN)
+  expect_identical(additive_cumulative(NA_real_), NA_real_)
+  expect_identical(additive_cumulative(Inf), 1)
+  expect_identical(additive_cumulative(-Inf), 0)
+  expect_identical(additive_cumulative(0), 0.5)
+})
+
 test_that("exp_function returns the declared values outside the reduction band", {
   expect_identical(exp_function(NaN), NaN)
   expect_identical(exp_function(NA_real_), NA_real_)

--- a/r/pragmastat/tests/testthat/test-exp-function.R
+++ b/r/pragmastat/tests/testthat/test-exp-function.R
@@ -1,11 +1,11 @@
-# The scaling step of portable_exp is spelled 2^n because R has no ldexp. The other ports
+# The scaling step of exp_function is spelled 2^n because R has no ldexp. The other ports
 # name one (Go math.Ldexp, C# Math.ScaleB, Kotlin Math.scalb, Python math.ldexp, Rust a
 # bit-pattern constructor) and get exactness from its contract; here "^" is a libm pow call,
 # so exactness is a property of the platform rather than of the language. That makes it a
 # claim to check rather than one to assume: a single inexact 2^n would move the result of
 # every exponential that reduces to that k, and the whole point of this function is that the
 # seven implementations return the same bits.
-test_that("2^n is exact for every n portable_exp can reach", {
+test_that("2^n is exact for every n exp_function can reach", {
   # k = floor(y/ln2 + 1/2) over the whole band the cutoffs admit, then the two exponents
   # the split scaling forms from it. Derived from the constants rather than written down,
   # so widening a cutoff widens the test with it.
@@ -35,9 +35,9 @@ test_that("2^n is exact for every n portable_exp can reach", {
 #
 # expect_exact, never a tolerance: the manifest declares this suite exact, and a tolerance here
 # passes on precisely the divergence the suite exists to catch.
-test_that("portable_exp reproduces the shared portable-exp fixture bit for bit", {
+test_that("exp_function reproduces the shared exp-function fixture bit for bit", {
   repo_root <- find_repo_root()
-  test_data_dir <- file.path(repo_root, "tests", "portable-exp")
+  test_data_dir <- file.path(repo_root, "tests", "exp-function")
 
   json_files <- list.files(test_data_dir, pattern = "\\.json$", full.names = TRUE)
   expect_true(length(json_files) > 0, "No JSON test files found")
@@ -51,7 +51,7 @@ test_that("portable_exp reproduces the shared portable-exp fixture bit for bit",
   for (json_file in json_files) {
     label <- basename(json_file)
     test_case <- jsonlite::fromJSON(json_file)
-    expect_identical(test_case$input$name, "portable_exp", info = paste(label, "suite name"))
+    expect_identical(test_case$input$name, "exp_function", info = paste(label, "suite name"))
 
     args <- as.double(test_case$input$arg)
     expected <- as.double(test_case$output)
@@ -62,7 +62,7 @@ test_that("portable_exp reproduces the shared portable-exp fixture bit for bit",
     # Only the outputs are compared. JSON does not distinguish -0 from 0, so the two signed
     # zeros in boundaries.json both arrive as +0; both exponentiate to 1, so nothing is lost,
     # and comparing the inputs would turn a property of the format into a failure.
-    actual <- vapply(args, portable_exp, numeric(1))
+    actual <- vapply(args, exp_function, numeric(1))
     expect_exact(actual, expected, label)
 
     checked <- checked + length(args)
@@ -82,19 +82,19 @@ test_that("portable_exp reproduces the shared portable-exp fixture bit for bit",
 # it would pass just as happily on seven copies of the same wrong reduction. This is the
 # open end of it. The polynomial and the range reduction are supposed to reproduce the true
 # exponential to a couple of ulp, and R's own exp is an independent witness to that.
-test_that("portable_exp tracks the platform exponential to about 2 ulp", {
+test_that("exp_function tracks the platform exponential to about 2 ulp", {
   ys <- seq(-700, 700, by = 0.37)
-  actual <- vapply(ys, portable_exp, numeric(1))
+  actual <- vapply(ys, exp_function, numeric(1))
   expected <- exp(ys)
   expect_lt(max(abs(actual - expected) / expected), 2^-51)
 })
 
-test_that("portable_exp returns the declared values outside the reduction band", {
-  expect_identical(portable_exp(NaN), NaN)
-  expect_identical(portable_exp(NA_real_), NA_real_)
-  expect_identical(portable_exp(710), Inf)
-  expect_identical(portable_exp(Inf), Inf)
-  expect_identical(portable_exp(-746), 0)
-  expect_identical(portable_exp(-Inf), 0)
-  expect_identical(portable_exp(0), 1)
+test_that("exp_function returns the declared values outside the reduction band", {
+  expect_identical(exp_function(NaN), NaN)
+  expect_identical(exp_function(NA_real_), NA_real_)
+  expect_identical(exp_function(710), Inf)
+  expect_identical(exp_function(Inf), Inf)
+  expect_identical(exp_function(-746), 0)
+  expect_identical(exp_function(-Inf), 0)
+  expect_identical(exp_function(0), 1)
 })

--- a/rs/AGENTS.md
+++ b/rs/AGENTS.md
@@ -23,8 +23,8 @@ rs/pragmastat/
 │   ├── sign_margin.rs             # Sign margin for binomial CDF inversion (internal)
 │   ├── signed_rank_margin.rs      # Signed-rank margin computation (internal)
 │   ├── min_misrate.rs             # Minimum achievable misrate calculation (internal)
-│   ├── gauss_cdf.rs               # Standard normal CDF (Chebyshev erf/erfc fit) (internal)
-│   ├── portable_exp.rs            # Reproducible exp, replacing the platform's (internal)
+│   ├── additive_cumulative.rs            # Standard normal CDF (Chebyshev erf/erfc fit) (internal)
+│   ├── exp_function.rs            # Reproducible exp, replacing the platform's (internal)
 │   ├── rng.rs                     # Deterministic xoshiro256++ PRNG
 │   ├── distributions/             # Sampling distributions (Uniform, Additive, Exp, Power, Multiplic)
 │   ├── center_impl.rs             # O(n log n) Hodges-Lehmann algorithm (internal)
@@ -46,9 +46,11 @@ rs/pragmastat/
 │   ├── error_tests.rs                     # Error path coverage
 │   ├── invariance_tests.rs                # Mathematical property tests
 │   ├── metrology_tests.rs                 # Bounds unit re-attachment
+│   ├── negative_zero_tests.rs             # No estimator returns a negative zero
 │   ├── performance_tests.rs               # Performance smoke test
 │   ├── reference_tests.rs                 # JSON fixture validation
-│   └── sample_bounds_consistency_tests.rs # Sample vs raw bounds on unsorted input
+│   ├── sample_bounds_consistency_tests.rs # Sample vs raw bounds on unsorted input
+│   └── shift_overflow_tests.rs            # Shift search bounds on extreme finite input
 └── examples/
     └── demo.rs
 ```

--- a/rs/pragmastat/src/additive_cumulative.rs
+++ b/rs/pragmastat/src/additive_cumulative.rs
@@ -1,18 +1,18 @@
 //! Standard normal CDF.
 
-use crate::portable_exp::portable_exp;
+use crate::exp_function::exp_function;
 
 /// Computes the standard normal CDF: `P(Z <= x)` for a standard normal `Z`.
 ///
 /// Two Chebyshev-fitted Horner chains and one exponential. The coefficients are produced by
-/// `tests/oracles/fit_gauss_cdf.py` against a reference good to 36 digits, so they are
+/// `tests/oracles/fit_additive_cumulative.py` against a reference good to 36 digits, so they are
 /// reproducible rather than transcribed.
 ///
 /// Every product is written as `p * u + c` and never as `p.mul_add(u, c)`. rustc does not
 /// contract on its own, so the two roundings this spells out are the two roundings that run,
 /// which is what the other six implementations do. `rs:check:fma` keeps it that way.
-pub fn gauss_cdf(x: f64) -> f64 {
-    let t = x.abs() / std::f64::consts::SQRT_2;
+pub fn additive_cumulative(z: f64) -> f64 {
+    let t = z.abs() / std::f64::consts::SQRT_2;
     if t < 0.5 {
         // erf(t)/t as a polynomial in u = 8*t^2 - 1.
         let s = t * t;
@@ -30,7 +30,7 @@ pub fn gauss_cdf(x: f64) -> f64 {
         p = p * u - 0.04364205888669792;
         p = p * u + 1.0830752376761712;
         let erf = t * p;
-        return if x >= 0.0 {
+        return if z >= 0.0 {
             0.5 * (1.0 + erf)
         } else {
             0.5 * (1.0 - erf)
@@ -69,10 +69,10 @@ pub fn gauss_cdf(x: f64) -> f64 {
         p = p * u + 0.09925390090168178;
         p = p * u - 0.15121195850373031;
         p = p * u + 0.21849873453703333;
-        erfc = portable_exp(-(t * t)) * p;
+        erfc = exp_function(-(t * t)) * p;
     }
 
-    if x >= 0.0 {
+    if z >= 0.0 {
         1.0 - 0.5 * erfc
     } else {
         0.5 * erfc

--- a/rs/pragmastat/src/additive_cumulative.rs
+++ b/rs/pragmastat/src/additive_cumulative.rs
@@ -12,6 +12,11 @@ use crate::exp_function::exp_function;
 /// contract on its own, so the two roundings this spells out are the two roundings that run,
 /// which is what the other six implementations do. `rs:check:fma` keeps it that way.
 pub fn additive_cumulative(z: f64) -> f64 {
+    // NaN satisfies neither comparison below, so without this it would leave the tail branch
+    // as a finite 0 or 1 and an undefined input would be answered rather than reported.
+    if z.is_nan() {
+        return z;
+    }
     let t = z.abs() / std::f64::consts::SQRT_2;
     if t < 0.5 {
         // erf(t)/t as a polynomial in u = 8*t^2 - 1.
@@ -76,5 +81,22 @@ pub fn additive_cumulative(z: f64) -> f64 {
         1.0 - 0.5 * erfc
     } else {
         0.5 * erfc
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::additive_cumulative;
+
+    /// Both of the function's range comparisons are false for a NaN, so without an explicit guard
+    /// it leaves the tail branch as a finite 0 or 1: an undefined input answered rather than
+    /// reported. The approximation this replaced propagated NaN.
+    #[test]
+    fn carries_nan_through_and_answers_both_infinities() {
+        assert!(additive_cumulative(f64::NAN).is_nan());
+        assert_eq!(additive_cumulative(f64::INFINITY), 1.0);
+        assert_eq!(additive_cumulative(f64::NEG_INFINITY), 0.0);
+        assert_eq!(additive_cumulative(0.0), 0.5);
+        assert_eq!(additive_cumulative(-0.0), 0.5);
     }
 }

--- a/rs/pragmastat/src/exp_function.rs
+++ b/rs/pragmastat/src/exp_function.rs
@@ -10,7 +10,7 @@
 #[allow(clippy::approx_constant)]
 const INV_LN2: f64 = 1.4426950408889634;
 
-/// High half of ln 2. Split so that `k * LN2_HI` is exact: `LN2_HI` carries 33 significant bits
+/// High half of ln 2. Split so that `k * LN2_HI` is exact: `LN2_HI` carries 32 significant bits
 /// and `|k|` needs at most 11, which leaves the product inside the 53 available. Without the
 /// split the reduction would lose the low bits of `r`, and `r` is where the accuracy lives.
 const LN2_HI: f64 = 0.6931471803691238;
@@ -26,7 +26,7 @@ const LN2_LO: f64 = 1.9082149292705877e-10;
 /// equivalent (`math.Ldexp`, `Math.ScaleB`, `Math.scalb`, `math.ldexp`); this is the same value
 /// they get.
 ///
-/// The cutoffs in `portable_exp` bound `n` to roughly `[-538, 512]`, comfortably inside the
+/// The cutoffs in `exp_function` bound `n` to roughly `[-538, 512]`, comfortably inside the
 /// normal range. The assertion is here because a hand-built exponent field, unlike a library
 /// call, has no defined behavior outside it: it would silently produce a denormal, an
 /// infinity or a NaN rather than a wrong-but-obvious answer.
@@ -63,7 +63,7 @@ fn pow2(n: i32) -> f64 {
 ///
 /// Every product is written as `a * b + c` and never as `a.mul_add(b, c)`, for the reason given
 /// at the top of `lib.rs`. `rs:check:fma` is the guard.
-pub(crate) fn portable_exp(y: f64) -> f64 {
+pub(crate) fn exp_function(y: f64) -> f64 {
     if y.is_nan() {
         return y;
     }
@@ -114,7 +114,7 @@ pub(crate) fn portable_exp(y: f64) -> f64 {
 
 #[cfg(test)]
 mod tests {
-    use super::{INV_LN2, portable_exp, pow2};
+    use super::{INV_LN2, exp_function, pow2};
 
     /// The claim the `approx_constant` suppression rests on.
     #[test]
@@ -149,7 +149,7 @@ mod tests {
         let steps = 200_000;
         for i in 0..=steps {
             let y = -745.0 + (709.0 - (-745.0)) * (i as f64) / (steps as f64);
-            let ours = portable_exp(y);
+            let ours = exp_function(y);
             let theirs = y.exp();
             // ulp of the reference value, from the neighbor above it.
             let next = f64::from_bits(theirs.to_bits() + 1);
@@ -168,11 +168,11 @@ mod tests {
 
     #[test]
     fn cutoffs_and_nan() {
-        assert!(portable_exp(f64::NAN).is_nan());
-        assert_eq!(portable_exp(709.8), f64::INFINITY);
-        assert_eq!(portable_exp(f64::INFINITY), f64::INFINITY);
-        assert_eq!(portable_exp(-745.3), 0.0);
-        assert_eq!(portable_exp(f64::NEG_INFINITY), 0.0);
-        assert_eq!(portable_exp(0.0), 1.0);
+        assert!(exp_function(f64::NAN).is_nan());
+        assert_eq!(exp_function(709.8), f64::INFINITY);
+        assert_eq!(exp_function(f64::INFINITY), f64::INFINITY);
+        assert_eq!(exp_function(-745.3), 0.0);
+        assert_eq!(exp_function(f64::NEG_INFINITY), 0.0);
+        assert_eq!(exp_function(0.0), 1.0);
     }
 }

--- a/rs/pragmastat/src/exp_function.rs
+++ b/rs/pragmastat/src/exp_function.rs
@@ -100,8 +100,8 @@ pub(crate) fn exp_function(y: f64) -> f64 {
     // falls off the end. Reconstructing the same sum from the two halves of the reduction keeps
     // them, and costs nothing, being the same operations in a different order. Measured against a
     // 60-digit reference over the band these estimators reach, it halves the worst relative error,
-    // from 2.19e-16 to 1.20e-16, and raises the share of correctly rounded results from 72.6% to
-    // 90.0%. That is where fdlibm sits, which reaches it with a division this does not need.
+    // from 2.19e-16 to 1.28e-16, and raises the share of correctly rounded results from 72.6% to
+    // 90.3%. That is where fdlibm sits, which reaches it with a division this does not need.
     let p = 1.0 - ((lo - r * r * q) - hi);
 
     // Two scalings rather than one. Splitting k in half keeps the first factor inside the
@@ -164,6 +164,34 @@ mod tests {
             worst_ulp <= 2.0,
             "worst disagreement with the platform exp: {worst_ulp} ulp at y = {worst_at}"
         );
+    }
+
+    /// Both margins binary-search an expansion whose density term is this function, under the
+    /// assumption that the expansion is monotone in the index. A single inversion here would let
+    /// the search return either neighbor, and the two neighbors are different confidence bounds.
+    ///
+    /// The sweep walks adjacent doubles rather than a grid: an inversion between two representable
+    /// arguments is what the search can hit, and a grid steps straight over it. One port suffices
+    /// because all seven return identical bits on every argument, which the shared fixture pins.
+    #[test]
+    fn monotone_across_adjacent_doubles() {
+        for start in [-745.0, -100.0, -1.0, -0.3, 0.0, 0.3, 1.0, 100.0, 709.0] {
+            let mut y = start;
+            let mut previous = exp_function(y);
+            for _ in 0..20_000 {
+                y = f64::from_bits(if y >= 0.0 {
+                    y.to_bits() + 1
+                } else {
+                    y.to_bits() - 1
+                });
+                let current = exp_function(y);
+                assert!(
+                    current >= previous,
+                    "exp_function inverted at y = {y}: {current} < {previous}"
+                );
+                previous = current;
+            }
+        }
     }
 
     #[test]

--- a/rs/pragmastat/src/exp_function_tests.rs
+++ b/rs/pragmastat/src/exp_function_tests.rs
@@ -134,10 +134,23 @@ fn test_exp_function_reference() {
         }
     }
 
-    assert!(
-        checked > 0,
-        "No arguments were checked out of {} files",
+    // The size of the generated fixture: four files, 1032 arguments. Pinned rather than counted
+    // from the directory, because counting the directory and then asserting the count matches the
+    // directory asserts nothing. The other six ports pin the same two numbers; a loader that only
+    // asserts it did some work cannot see a file that stopped being read or an argument list that
+    // was truncated.
+    const FIXTURE_FILE_COUNT: usize = 4;
+    const FIXTURE_ARGUMENT_COUNT: usize = 1032;
+
+    assert_eq!(
+        json_files.len(),
+        FIXTURE_FILE_COUNT,
+        "exp-function: read {} files, expected {FIXTURE_FILE_COUNT}",
         json_files.len()
+    );
+    assert_eq!(
+        checked, FIXTURE_ARGUMENT_COUNT,
+        "exp-function: compared {checked} arguments, expected {FIXTURE_ARGUMENT_COUNT}"
     );
 
     assert!(

--- a/rs/pragmastat/src/exp_function_tests.rs
+++ b/rs/pragmastat/src/exp_function_tests.rs
@@ -1,6 +1,6 @@
-//! The reproducible exponential against the shared `portable-exp` fixture.
+//! The reproducible exponential against the shared `exp-function` fixture.
 //!
-//! Every port carries its own `portable_exp` because IEEE 754 fixes nothing about the
+//! Every port carries its own `exp_function` because IEEE 754 fixes nothing about the
 //! exponential, and the margins turn a last-bit difference into a different order statistic and
 //! so into a different confidence interval. Until this suite existed, nothing compared the seven
 //! implementations directly: they met only through the margin fixtures, which reach the
@@ -10,11 +10,11 @@
 //! payload. A tolerance here would pass on precisely the divergence the suite exists to catch:
 //! two implementations one ULP apart agree to 1e-15 and disagree on the interval.
 //!
-//! This module lives in `src` rather than in `tests/` because `portable_exp` is `pub(crate)`,
+//! This module lives in `src` rather than in `tests/` because `exp_function` is `pub(crate)`,
 //! the same reason `pairwise_margin_tests` and `signed_rank_margin_tests` do.
 
 use crate::conformance::bitwise_mismatch;
-use crate::portable_exp::portable_exp;
+use crate::exp_function::exp_function;
 use serde::Deserialize;
 use std::fs;
 use std::path::PathBuf;
@@ -25,14 +25,14 @@ use std::path::PathBuf;
 /// single-value suite, so a file from a different suite deserializes into this struct without
 /// complaint and would be silently checked against the wrong function.
 #[derive(Debug, Deserialize)]
-struct PortableExpInput {
+struct ExpFunctionInput {
     name: String,
     arg: Vec<f64>,
 }
 
 #[derive(Debug, Deserialize)]
-struct PortableExpTestCase {
-    input: PortableExpInput,
+struct ExpFunctionTestCase {
+    input: ExpFunctionInput,
     output: Vec<f64>,
 }
 
@@ -48,7 +48,7 @@ fn find_repo_root() -> PathBuf {
     }
 }
 
-/// Checks `portable_exp` on every argument of every file in the suite.
+/// Checks `exp_function` on every argument of every file in the suite.
 ///
 /// Only the outputs are compared. `boundaries.json` lists both `0` and `-0`, which JSON does not
 /// distinguish and which serde therefore hands over as `+0.0` twice; both are arguments to
@@ -60,9 +60,9 @@ fn find_repo_root() -> PathBuf {
 /// correctly rounded, and an ULP at that magnitude is the entire value. A parser that mangled
 /// them would fail here rather than pass quietly, since the comparison is on payloads.
 #[test]
-fn test_portable_exp_reference() {
+fn test_exp_function_reference() {
     let repo_root = find_repo_root();
-    let test_data_dir = repo_root.join("tests").join("portable-exp");
+    let test_data_dir = repo_root.join("tests").join("exp-function");
 
     if !test_data_dir.exists() {
         panic!("Test data directory not found: {test_data_dir:?}");
@@ -94,12 +94,12 @@ fn test_portable_exp_reference() {
 
     for json_file in &json_files {
         let content = fs::read_to_string(json_file).unwrap();
-        let test_case: PortableExpTestCase = serde_json::from_str(&content).unwrap();
+        let test_case: ExpFunctionTestCase = serde_json::from_str(&content).unwrap();
         let file_name = json_file.file_name().unwrap();
 
         assert_eq!(
-            test_case.input.name, "portable_exp",
-            "{file_name:?}: expected the portable_exp suite, got \"{}\"",
+            test_case.input.name, "exp_function",
+            "{file_name:?}: expected the exp_function suite, got \"{}\"",
             test_case.input.name
         );
         assert_eq!(
@@ -127,7 +127,7 @@ fn test_portable_exp_reference() {
             if let Some(mismatch) = bitwise_mismatch(
                 &format!("exp({arg}) [arg {i}]"),
                 expected,
-                portable_exp(arg),
+                exp_function(arg),
             ) {
                 failures.push(format!("{file_name:?}: {mismatch}"));
             }

--- a/rs/pragmastat/src/lib.rs
+++ b/rs/pragmastat/src/lib.rs
@@ -26,11 +26,11 @@ pub mod measurement_unit;
 pub mod sample;
 pub mod unit_registry;
 
+pub(crate) mod additive_cumulative;
 pub(crate) mod binomial;
-pub(crate) mod gauss_cdf;
+pub(crate) mod exp_function;
 pub(crate) mod min_misrate;
 pub(crate) mod pairwise_margin;
-pub(crate) mod portable_exp;
 pub mod rng;
 pub(crate) mod sign_margin;
 pub(crate) mod signed_rank_margin;
@@ -54,9 +54,9 @@ mod conformance;
 #[cfg(test)]
 mod disparity_bounds_tests;
 #[cfg(test)]
-mod pairwise_margin_tests;
+mod exp_function_tests;
 #[cfg(test)]
-mod portable_exp_tests;
+mod pairwise_margin_tests;
 #[cfg(test)]
 mod ratio_bounds_tests;
 #[cfg(test)]

--- a/rs/pragmastat/src/pairwise_margin.rs
+++ b/rs/pragmastat/src/pairwise_margin.rs
@@ -150,8 +150,8 @@ fn edgeworth_cdf(n: usize, m: usize, u: u64) -> f64 {
     let z = (u_f64 - mu - 0.5) / su;
 
     // Standard normal PDF and CDF
-    let phi = crate::portable_exp::portable_exp(-z * z / 2.0) / (2.0 * std::f64::consts::PI).sqrt();
-    let big_phi = crate::gauss_cdf::gauss_cdf(z);
+    let phi = crate::exp_function::exp_function(-z * z / 2.0) / (2.0 * std::f64::consts::PI).sqrt();
+    let big_phi = crate::additive_cumulative::additive_cumulative(z);
 
     // Pre-compute powers of n and m for efficiency
     let n2 = n_f64 * n_f64;

--- a/rs/pragmastat/src/signed_rank_margin.rs
+++ b/rs/pragmastat/src/signed_rank_margin.rs
@@ -2,8 +2,8 @@
 //!
 //! One-sample analog of PairwiseMargin using Wilcoxon signed-rank distribution.
 
+use crate::additive_cumulative::additive_cumulative;
 use crate::assumptions::AssumptionError;
-use crate::gauss_cdf::gauss_cdf;
 use crate::min_misrate::min_achievable_misrate_one_sample;
 
 /// Maximum n for exact computation. Limited to 63 because 2^n must fit in a 64-bit integer.
@@ -116,8 +116,8 @@ fn signed_rank_edgeworth_cdf(n: usize, w: usize) -> f64 {
 
     // +0.5 continuity correction: computing P(W ≤ w) for a left-tail discrete CDF
     let z = (w as f64 - mu + 0.5) / sigma;
-    let phi = crate::portable_exp::portable_exp(-z * z / 2.0) / (2.0 * std::f64::consts::PI).sqrt();
-    let big_phi = gauss_cdf(z);
+    let phi = crate::exp_function::exp_function(-z * z / 2.0) / (2.0 * std::f64::consts::PI).sqrt();
+    let big_phi = additive_cumulative(z);
 
     let kappa4 =
         -n_f64 * (n_f64 + 1.0) * (2.0 * n_f64 + 1.0) * (3.0 * n_f64 * n_f64 + 3.0 * n_f64 - 1.0)

--- a/tests/README.md
+++ b/tests/README.md
@@ -58,13 +58,13 @@ tests/
 ├── avg-spread-bounds/   # AvgSpreadBounds estimator tests
 ├── pairwise-margin/     # PairwiseMargin function tests
 ├── signed-rank-margin/  # SignedRankMargin function tests
-├── portable-exp/        # The reproducible exponential, by payload
+├── exp-function/        # The reproducible exponential, by payload
 │
 │   # Other
 └── distributions/       # Distribution sampling tests
 ```
 
-`portable-exp/` is the only suite that tests a function no public API exposes. It is there because
+`exp-function/` is the only suite that tests a function no public API exposes. It is there because
 the margins reach an exponential, IEEE 754 fixes nothing about one, and a last-bit difference
 there selects a different order statistic — so the seven implementations evaluate their own rather
 than the platform's. Every other suite reaches that function only through a margin, which covers

--- a/tests/exp-function/boundaries.json
+++ b/tests/exp-function/boundaries.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "name": "portable_exp",
+    "name": "exp_function",
     "arg": [
       0,
       -0,

--- a/tests/exp-function/edgeworth-band.json
+++ b/tests/exp-function/edgeworth-band.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "name": "portable_exp",
+    "name": "exp_function",
     "arg": [
       -40,
       -39.8,

--- a/tests/exp-function/finite-range.json
+++ b/tests/exp-function/finite-range.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "name": "portable_exp",
+    "name": "exp_function",
     "arg": [
       -745,
       -741.365,

--- a/tests/exp-function/working-band.json
+++ b/tests/exp-function/working-band.json
@@ -1,6 +1,6 @@
 {
   "input": {
-    "name": "portable_exp",
+    "name": "exp_function",
     "arg": [
       -18.5,
       -18.45375,

--- a/tests/manifest.json
+++ b/tests/manifest.json
@@ -210,9 +210,9 @@
       "description": "SignedRankMargin function tests",
       "languages": ["cs", "go", "kt", "py", "r", "rs", "ts"]
     },
-    "portable-exp": {
+    "exp-function": {
       "conformance": "exact",
-      "directory": "portable-exp",
+      "directory": "exp-function",
       "generator": "cs/Pragmastat.TestGenerator",
       "pattern": "*.json",
       "description": "The reproducible exponential, compared by binary64 payload",

--- a/tests/oracles/additive_reference.py
+++ b/tests/oracles/additive_reference.py
@@ -1,6 +1,6 @@
 """A reference for the normal distribution function, good to more digits than binary64 has.
 
-Used to fit the coefficients in gauss_cdf and to check what they deliver. It depends on nothing
+Used to fit the coefficients in additive_cumulative and to check what they deliver. It depends on nothing
 beyond the standard library on purpose: an oracle with a dependency is an oracle that stops
 running, and this repository has already had one of those.
 

--- a/tests/oracles/fit_additive_cumulative.py
+++ b/tests/oracles/fit_additive_cumulative.py
@@ -2,7 +2,7 @@ import sys
 from decimal import Decimal as D, getcontext
 sys.path.insert(0, ".")
 getcontext().prec = 80
-from gauss_reference import erf_series, erfc_cf
+from additive_reference import erf_series, erfc_cf
 from chebyshev import cheb_fit, horner
 
 def erfc_d(x): return (1 - erf_series(x)) if x < D("2.5") else erfc_cf(x)

--- a/tests/oracles/fit_exp.py
+++ b/tests/oracles/fit_exp.py
@@ -70,7 +70,7 @@ def fmt(p):
 
 
 # ln2 split so that k * LN2_HI is exact for every k the reduction can produce. LN2_HI keeps
-# the leading 33 bits and k needs at most 11, so the product fits the 53 available.
+# the leading 32 bits and k needs at most 11, so the product fits the 53 available.
 LN2_HI = float.fromhex("0x1.62e42fee00000p-1")
 LN2_LO = float(LN2 - D(LN2_HI))
 

--- a/tools/src/main.rs
+++ b/tools/src/main.rs
@@ -158,10 +158,12 @@ const PAGES: &[Page] = &[
     Page { slug: "sign-margin", file: "sign-margin/sign-margin", title: "SignMargin", order: 35, group: Some("Auxiliary"), heading_offset: -1 },
     Page { slug: "pairwise-margin", file: "pairwise-margin/pairwise-margin", title: "PairwiseMargin", order: 36, group: Some("Auxiliary"), heading_offset: -1 },
     Page { slug: "signed-rank-margin", file: "signed-rank-margin/signed-rank-margin", title: "SignedRankMargin", order: 37, group: Some("Auxiliary"), heading_offset: -1 },
+    Page { slug: "additive-cumulative", file: "additive-cumulative/additive-cumulative", title: "AdditiveCumulative", order: 38, group: Some("Auxiliary"), heading_offset: -1 },
+    Page { slug: "exp-function", file: "exp-function/exp-function", title: "ExpFunction", order: 39, group: Some("Auxiliary"), heading_offset: -1 },
     // Appendix
-    Page { slug: "assumptions", file: "assumptions/assumptions", title: "Assumptions", order: 38, group: Some("Appendix"), heading_offset: 0 },
-    Page { slug: "foundations", file: "foundations/foundations", title: "Foundations", order: 39, group: Some("Appendix"), heading_offset: 0 },
-    Page { slug: "methodology", file: "methodology/methodology", title: "Methodology", order: 40, group: Some("Appendix"), heading_offset: 0 },
+    Page { slug: "assumptions", file: "assumptions/assumptions", title: "Assumptions", order: 40, group: Some("Appendix"), heading_offset: 0 },
+    Page { slug: "foundations", file: "foundations/foundations", title: "Foundations", order: 41, group: Some("Appendix"), heading_offset: 0 },
+    Page { slug: "methodology", file: "methodology/methodology", title: "Methodology", order: 42, group: Some("Appendix"), heading_offset: 0 },
 ];
 
 /// Fail the run if any internal link had no entry in the cross-reference map

--- a/tools/src/xref.rs
+++ b/tools/src/xref.rs
@@ -80,6 +80,11 @@ impl XRefMap {
             "sec-signed-rank-margin".into(),
             "/signed-rank-margin".into(),
         );
+        mappings.insert(
+            "sec-additive-cumulative".into(),
+            "/additive-cumulative".into(),
+        );
+        mappings.insert("sec-exp-function".into(), "/exp-function".into());
         mappings.insert("sec-rng".into(), "/rng".into());
         mappings.insert("sec-uniform-int".into(), "/uniform-int".into());
         mappings.insert("sec-uniform-float".into(), "/uniform-float".into());
@@ -138,6 +143,14 @@ impl XRefMap {
         mappings.insert(
             "sec-alg-signed-rank-margin".into(),
             "/signed-rank-margin#algorithm".into(),
+        );
+        mappings.insert(
+            "sec-alg-additive-cumulative".into(),
+            "/additive-cumulative#algorithm".into(),
+        );
+        mappings.insert(
+            "sec-alg-exp-function".into(),
+            "/exp-function#algorithm".into(),
         );
 
         // Notes sections -> per-function pages

--- a/ts/AGENTS.md
+++ b/ts/AGENTS.md
@@ -26,8 +26,8 @@ ts/
 │   ├── signedRankMargin.ts    # Signed-rank margin computation
 │   ├── minMisrate.ts          # Minimum achievable misrate calculation
 │   ├── binomial.ts            # Binomial coefficient shared by the two above (internal)
-│   ├── gaussCdf.ts            # Standard normal CDF (Chebyshev-fitted erf/erfc)
-│   ├── portableExp.ts         # The exponential the margin path uses instead of Math.exp
+│   ├── additiveCumulative.ts         # Standard normal CDF (Chebyshev-fitted erf/erfc)
+│   ├── expFunction.ts         # The exponential the margin path uses instead of Math.exp
 │   ├── rng.ts                 # Deterministic xoshiro256++ PRNG
 │   ├── xoshiro256.ts          # PRNG core implementation
 │   ├── centerImpl.ts          # O(n log n) Hodges-Lehmann algorithm
@@ -38,7 +38,7 @@ ts/
 │   └── distributions/         # Uniform, Additive, Exp, Power, Multiplic
 ├── tests/
 │   ├── bitwise.ts                 # The binary64-payload comparison every exact suite uses
-│   ├── portableExp.test.ts        # 2**n exactness and the cross-port payloads of portableExp
+│   ├── expFunction.test.ts        # 2**n exactness and the cross-port payloads of expFunction
 │   ├── reference.test.ts          # JSON fixture validation
 │   ├── invariance.test.ts         # Mathematical property tests
 │   ├── assumeSorted.test.ts       # assumeSorted=true vs default-path equivalence

--- a/ts/src/additiveCumulative.ts
+++ b/ts/src/additiveCumulative.ts
@@ -2,16 +2,16 @@
  * Standard normal CDF.
  */
 
-import { portableExp } from './portableExp';
+import { expFunction } from './expFunction';
 
 /**
  * Computes the standard normal CDF.
  *
  * Two Chebyshev-fitted Horner chains and one exponential. The coefficients are produced by
- * tests/oracles/fit_gauss_cdf.py against a reference good to 36 digits, so they are
+ * tests/oracles/fit_additive_cumulative.py against a reference good to 36 digits, so they are
  * reproducible rather than transcribed.
  *
- * The exponential is portableExp rather than Math.exp: the platform's differs between
+ * The exponential is expFunction rather than Math.exp: the platform's differs between
  * runtimes in the last bit, and this value reaches a comparison that selects an integer.
  *
  * No product needs pinning here: ECMAScript specifies every multiply and add as a separate
@@ -20,8 +20,8 @@ import { portableExp } from './portableExp';
  * @param x -infinity..+infinity
  * @returns Area under the standard normal curve from -infinity to x
  */
-export function gaussCdf(x: number): number {
-  const t = Math.abs(x) / Math.SQRT2;
+export function additiveCumulative(z: number): number {
+  const t = Math.abs(z) / Math.SQRT2;
   if (t < 0.5) {
     const s = t * t;
     const u = 8.0 * s - 1.0;
@@ -38,7 +38,7 @@ export function gaussCdf(x: number): number {
     p = p * u - 0.04364205888669792;
     p = p * u + 1.0830752376761712;
     const erf = t * p;
-    return x >= 0 ? 0.5 * (1.0 + erf) : 0.5 * (1.0 - erf);
+    return z >= 0 ? 0.5 * (1.0 + erf) : 0.5 * (1.0 - erf);
   }
 
   let erfc = 0.0;
@@ -71,8 +71,8 @@ export function gaussCdf(x: number): number {
     p = p * u + 0.09925390090168178;
     p = p * u - 0.15121195850373031;
     p = p * u + 0.21849873453703333;
-    erfc = portableExp(-(t * t)) * p;
+    erfc = expFunction(-(t * t)) * p;
   }
 
-  return x >= 0 ? 1.0 - 0.5 * erfc : 0.5 * erfc;
+  return z >= 0 ? 1.0 - 0.5 * erfc : 0.5 * erfc;
 }

--- a/ts/src/additiveCumulative.ts
+++ b/ts/src/additiveCumulative.ts
@@ -21,6 +21,11 @@ import { expFunction } from './expFunction';
  * @returns Area under the standard normal curve from -infinity to x
  */
 export function additiveCumulative(z: number): number {
+  // NaN satisfies neither comparison below, so without this it would leave the tail branch as a
+  // finite 0 or 1 and an undefined input would be answered rather than reported.
+  if (Number.isNaN(z)) {
+    return z;
+  }
   const t = Math.abs(z) / Math.SQRT2;
   if (t < 0.5) {
     const s = t * t;

--- a/ts/src/expFunction.ts
+++ b/ts/src/expFunction.ts
@@ -5,7 +5,7 @@
 /**
  * Constants of the range reduction, emitted by tests/oracles/fit_exp.py.
  *
- * ln 2 is split so that k*LN2_HI is exact: LN2_HI carries 33 significant bits and |k| needs at
+ * ln 2 is split so that k*LN2_HI is exact: LN2_HI carries 32 significant bits and |k| needs at
  * most 11, which leaves the product inside the 53 available. Without the split the reduction
  * would lose the low bits of r, and r is where the accuracy lives.
  */
@@ -19,8 +19,8 @@ const LN2_LO = 1.9082149292705877e-10;
  * JavaScript has no ldexp, so this is the exponentiation operator. ECMAScript defines that
  * operator as an implementation-approximated function rather than a correctly-rounded one, so
  * exactness here is a claim about the runtime and not about the standard. It is checked rather
- * than assumed: tests/portableExp.test.ts compares this against a bit-pattern construction for
- * every exponent portableExp can reach, which is -538..512.
+ * than assumed: tests/expFunction.test.ts compares this against a bit-pattern construction for
+ * every exponent expFunction can reach, which is -538..512.
  *
  * @param n Integer exponent
  * @returns The power of two with that exponent
@@ -30,7 +30,7 @@ export function pow2(n: number): number {
 }
 
 /**
- * portableExp is the exponential every port evaluates, in place of the platform's.
+ * expFunction is the exponential every port evaluates, in place of the platform's.
  *
  * IEEE 754 fixes the result of each arithmetic operation and of the square root, and fixes
  * nothing about the exponential. Conforming libraries disagree in the last bit and do:
@@ -57,7 +57,7 @@ export function pow2(n: number): number {
  * @param y -infinity..+infinity
  * @returns e raised to y
  */
-export function portableExp(y: number): number {
+export function expFunction(y: number): number {
   if (Number.isNaN(y)) {
     return y;
   }

--- a/ts/src/pairwiseMargin.ts
+++ b/ts/src/pairwiseMargin.ts
@@ -7,9 +7,9 @@
 
 import { AssumptionError } from './assumptions';
 import { binomialCoefficient } from './binomial';
-import { gaussCdf } from './gaussCdf';
+import { additiveCumulative } from './additiveCumulative';
 import { minAchievableMisrateTwoSample } from './minMisrate';
-import { portableExp } from './portableExp';
+import { expFunction } from './expFunction';
 
 const MAX_EXACT_SIZE = 400;
 
@@ -148,11 +148,11 @@ function edgeworthCdf(n: number, m: number, u: number): number {
   // -0.5 continuity correction: computing P(U ≥ u) for a right-tail discrete CDF
   const z = (u - mu - 0.5) / su;
 
-  // Standard normal PDF and CDF. portableExp rather than Math.exp: the platform's exponential
+  // Standard normal PDF and CDF. expFunction rather than Math.exp: the platform's exponential
   // differs between runtimes in the last bit, and this density feeds a search that selects an
   // integer margin.
-  const phi = portableExp((-z * z) / 2) / Math.sqrt(2 * Math.PI);
-  const bigPhi = gaussCdf(z);
+  const phi = expFunction((-z * z) / 2) / Math.sqrt(2 * Math.PI);
+  const bigPhi = additiveCumulative(z);
 
   // Pre-compute powers of n and m for efficiency
   const n2 = n * n;

--- a/ts/src/signedRankMargin.ts
+++ b/ts/src/signedRankMargin.ts
@@ -4,9 +4,9 @@
  * One-sample analog of PairwiseMargin using Wilcoxon signed-rank distribution.
  */
 
-import { gaussCdf } from './gaussCdf';
+import { additiveCumulative } from './additiveCumulative';
 import { minAchievableMisrateOneSample } from './minMisrate';
-import { portableExp } from './portableExp';
+import { expFunction } from './expFunction';
 import { AssumptionError } from './assumptions';
 
 // Maximum n for exact computation. Limited to 63 because 2^n must fit in a BigInt
@@ -114,10 +114,10 @@ function signedRankEdgeworthCdf(n: number, w: number): number {
 
   // +0.5 continuity correction: computing P(W ≤ w) for a left-tail discrete CDF
   const z = (w - mu + 0.5) / sigma;
-  // portableExp rather than Math.exp: the platform's exponential differs between runtimes in
+  // expFunction rather than Math.exp: the platform's exponential differs between runtimes in
   // the last bit, and this density feeds a search that selects an integer margin.
-  const phi = portableExp((-z * z) / 2) / Math.sqrt(2 * Math.PI);
-  const bigPhi = gaussCdf(z);
+  const phi = expFunction((-z * z) / 2) / Math.sqrt(2 * Math.PI);
+  const bigPhi = additiveCumulative(z);
 
   const kappa4 = (-n * (n + 1) * (2 * n + 1) * (3 * n * n + 3 * n - 1)) / 240.0;
 

--- a/ts/tests/expFunction.test.ts
+++ b/ts/tests/expFunction.test.ts
@@ -1,4 +1,4 @@
-import { pow2, portableExp } from '../src/portableExp';
+import { pow2, expFunction } from '../src/expFunction';
 import { expectBitwise } from './bitwise';
 
 // The exponential is the one library call on the margin path that IEEE 754 leaves free, so
@@ -6,7 +6,7 @@ import { expectBitwise } from './bitwise';
 // tolerance.
 //
 // What is checked here is what the shared fixture cannot check. The agreement of the seven
-// implementations is checked by tests/portable-exp, argument by argument, loaded in
+// implementations is checked by tests/exp-function, argument by argument, loaded in
 // reference.test.ts; this file holds the two claims that fixture has no way to carry.
 //
 // The first is that `2 ** n` is exact. JavaScript has no ldexp, and ECMAScript defines the
@@ -29,13 +29,13 @@ function pow2FromExponentField(n: number): number {
   return scratch.getFloat64(0);
 }
 
-// Mirrors the cutoffs and the reciprocal of ln 2 in src/portableExp.ts, so that the exponent
+// Mirrors the cutoffs and the reciprocal of ln 2 in src/expFunction.ts, so that the exponent
 // range the scaling can reach is derived here rather than asserted from memory.
 const INV_LN2 = 1.4426950408889634;
 const MAX_ARG = 709.79;
 const MIN_ARG = -745.2;
 
-describe('portableExp', () => {
+describe('expFunction', () => {
   // k = floor(y*INV_LN2 + 1/2) is non-decreasing in y, so over the band the cutoffs admit it
   // is bounded by its values at the two ends. The scaling then uses trunc(k/2) and k - trunc(k/2).
   it('reaches exponents -538..512 and no others', () => {
@@ -60,13 +60,13 @@ describe('portableExp', () => {
   // The high cutoff itself is not the early return: `y > 709.79` is false at 709.79, so the
   // reduction runs and the scaling is what overflows. The early return is above it.
   it('overflows to infinity at the top of the range', () => {
-    expect(portableExp(MAX_ARG)).toBe(Infinity);
-    expect(portableExp(710)).toBe(Infinity);
+    expect(expFunction(MAX_ARG)).toBe(Infinity);
+    expect(expFunction(710)).toBe(Infinity);
   });
 
   it('carries the infinities and NaN through', () => {
-    expect(portableExp(Infinity)).toBe(Infinity);
-    expectBitwise('portableExp(-Infinity)', portableExp(-Infinity), 0);
-    expect(Number.isNaN(portableExp(NaN))).toBe(true);
+    expect(expFunction(Infinity)).toBe(Infinity);
+    expectBitwise('expFunction(-Infinity)', expFunction(-Infinity), 0);
+    expect(Number.isNaN(expFunction(NaN))).toBe(true);
   });
 });

--- a/ts/tests/expFunction.test.ts
+++ b/ts/tests/expFunction.test.ts
@@ -1,4 +1,5 @@
 import { pow2, expFunction } from '../src/expFunction';
+import { additiveCumulative } from '../src/additiveCumulative';
 import { expectBitwise } from './bitwise';
 
 // The exponential is the one library call on the margin path that IEEE 754 leaves free, so
@@ -68,5 +69,18 @@ describe('expFunction', () => {
     expect(expFunction(Infinity)).toBe(Infinity);
     expectBitwise('expFunction(-Infinity)', expFunction(-Infinity), 0);
     expect(Number.isNaN(expFunction(NaN))).toBe(true);
+  });
+});
+
+describe('additiveCumulative', () => {
+  // Both of the function's range comparisons are false for a NaN, so without an explicit guard
+  // it leaves the tail branch as a finite 0 or 1: an undefined input answered rather than
+  // reported. The approximation this replaced propagated NaN, so losing it would be a regression.
+  it('carries NaN through and answers both infinities', () => {
+    expect(Number.isNaN(additiveCumulative(NaN))).toBe(true);
+    expectBitwise('additiveCumulative(Infinity)', additiveCumulative(Infinity), 1);
+    expectBitwise('additiveCumulative(-Infinity)', additiveCumulative(-Infinity), 0);
+    expectBitwise('additiveCumulative(0)', additiveCumulative(0), 0.5);
+    expectBitwise('additiveCumulative(-0)', additiveCumulative(-0), 0.5);
   });
 });

--- a/ts/tests/reference.test.ts
+++ b/ts/tests/reference.test.ts
@@ -17,7 +17,7 @@ import {
 import { signedRankMargin } from '../src/signedRankMargin';
 import { AssumptionError } from '../src/assumptions';
 import { pairwiseMargin } from '../src/pairwiseMargin';
-import { portableExp } from '../src/portableExp';
+import { expFunction } from '../src/expFunction';
 import { Rng } from '../src/rng';
 import { Additive, Exp, Multiplic, Power, Uniform } from '../src/distributions';
 import { Sample } from '../src/sample';
@@ -845,7 +845,7 @@ describe('Reference Tests', () => {
     }
   });
 
-  // PortableExp tests
+  // ExpFunction tests
   //
   // The exponential every port evaluates in place of the platform's, checked directly.
   // Every other suite reaches it only through a margin, so it is exercised wherever an
@@ -864,8 +864,8 @@ describe('Reference Tests', () => {
   //
   // The fixture is not optional: it is committed beside the others and every port reads
   // it, so a missing directory throws here rather than skipping quietly.
-  describe('portable-exp', () => {
-    interface PortableExpData {
+  describe('exp-function', () => {
+    interface ExpFunctionData {
       input: { name: string; arg: number[] };
       output: number[];
     }
@@ -875,16 +875,16 @@ describe('Reference Tests', () => {
     // over the whole finite range, and 29 boundaries. Pinned rather than derived,
     // because a loader that finds three files out of four satisfies every other
     // assertion here by having less to compare. Raise it when the generator adds cases.
-    const PORTABLE_EXP_ARG_COUNT = 1032;
+    const EXP_FUNCTION_ARG_COUNT = 1032;
 
-    const dirPath = path.join(testDataPath, 'portable-exp');
+    const dirPath = path.join(testDataPath, 'exp-function');
     const testFiles = fs
       .readdirSync(dirPath)
       .filter((f) => f.endsWith('.json'))
       .sort();
 
     const suites = testFiles.map((fileName) => {
-      const data: PortableExpData = JSON.parse(
+      const data: ExpFunctionData = JSON.parse(
         fs.readFileSync(path.join(dirPath, fileName), 'utf8'),
       );
       return { fileName, name: data.input.name, args: data.input.arg, expected: data.output };
@@ -899,13 +899,13 @@ describe('Reference Tests', () => {
       const testName = fileName.replace('.json', '');
 
       it(`should pass ${testName}`, () => {
-        expect(name).toBe('portable_exp');
+        expect(name).toBe('exp_function');
         expect(args.length).toBeGreaterThan(0);
         expect(expected.length).toBe(args.length);
         for (let i = 0; i < args.length; i++) {
           expectBitwise(
-            `portable-exp/${fileName} arg[${i}]=${args[i]}`,
-            portableExp(args[i]),
+            `exp-function/${fileName} arg[${i}]=${args[i]}`,
+            expFunction(args[i]),
             expected[i],
           );
           compared++;
@@ -916,8 +916,8 @@ describe('Reference Tests', () => {
     // Runs after the per-file tests above, which increment `compared` once per comparison
     // actually made. A loader that finds nothing passes every one of them by running
     // nothing, so the count is what says the suite was exercised at all.
-    it(`compares all ${PORTABLE_EXP_ARG_COUNT} arguments`, () => {
-      expect(compared).toBe(PORTABLE_EXP_ARG_COUNT);
+    it(`compares all ${EXP_FUNCTION_ARG_COUNT} arguments`, () => {
+      expect(compared).toBe(EXP_FUNCTION_ARG_COUNT);
     });
   });
 


### PR DESCRIPTION
`AdditiveCumulative` answered `0.0` for a NaN in six ports and raised in R, because both of its range comparisons are false for one and it fell through to the tail branch. The function it replaced propagated NaN, so an undefined input used to be reported and had become answered. No fixture passes a NaN, so nothing caught it. Also finishes the signed-zero work in Go, where three exits had been missed.

Base is `fp/06-naming-and-chapters`.

## Appendix

The three Go exits: `Disparity` returned its quotient unwrapped, and `RatioBounds` and the average-spread bounds built a `Bounds` by struct literal, bypassing the constructor whose comment says every bounds estimator reaches its caller through it.
