### PR TITLE
Make the guards fail when they stop working

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,6 +337,9 @@ jobs:
     - name: Prose uses one spelling convention
       run: mise run tests:check:spelling
 
+    - name: Shipped coefficients match the scripts that produce them
+      run: mise run tests:check:coefficients
+
   ci-kt:
     runs-on: ubuntu-24.04
     steps:

--- a/cs/AGENTS.md
+++ b/cs/AGENTS.md
@@ -20,11 +20,11 @@ mise run cs:gen      # Generate reference test files
 cs/
 ├── Pragmastat/
 │   ├── Algorithms/
-│   │   ├── CenterImpl.cs           # O(n log n) Hodges-Lehmann center
-│   │   ├── CenterQuantilesImpl.cs  # Quantiles of pairwise averages via binary search
-│   │   ├── RatioImpl.cs            # Ratio quantiles via log-transform + ShiftImpl
-│   │   ├── ShiftImpl.cs            # O((m+n) log L) shift quantiles
-│   │   └── SpreadImpl.cs           # O(n log n) Shamos spread
+│   │   ├── CenterImpl.cs          # O(n log n) Hodges-Lehmann center
+│   │   ├── CenterQuantilesImpl.cs # Quantiles of pairwise averages via binary search
+│   │   ├── RatioImpl.cs           # Ratio quantiles via log-transform + ShiftImpl
+│   │   ├── ShiftImpl.cs           # O((m+n) log L) shift quantiles
+│   │   └── SpreadImpl.cs          # O(n log n) Shamos spread
 │   ├── Estimators/
 │   │   ├── IOneSampleEstimator.cs
 │   │   ├── ITwoSampleEstimator.cs
@@ -35,17 +35,17 @@ cs/
 │   ├── Functions/
 │   │   ├── PairwiseMargin.cs
 │   │   ├── ErrorFunction.cs
-│   │   ├── AdditiveCumulative.cs         # Standard normal CDF (Chebyshev-fitted erf/erfc)
-│   │   ├── ExpFunction.cs         # Reproducible exp: range reduction plus fitted polynomial
+│   │   ├── AdditiveCumulative.cs # Standard normal CDF (Chebyshev-fitted erf/erfc)
+│   │   ├── ExpFunction.cs        # Reproducible exp: range reduction plus fitted polynomial
 │   │   └── ...
-│   ├── Bounds.cs               # Lower/upper bound pair
-│   ├── Probability.cs          # Probability value type
-│   ├── Sample.cs               # Core sample type
-│   ├── Toolkit.cs              # Static API entry point
-│   └── Randomization/          # Rng, Xoshiro256
-├── Pragmastat.Demo/            # Demo application
-├── Pragmastat.Tests/           # Unit tests
-└── Pragmastat.TestGenerator/   # Reference test generator
+│   ├── Bounds.cs             # Lower/upper bound pair
+│   ├── Probability.cs        # Probability value type
+│   ├── Sample.cs             # Core sample type
+│   ├── Toolkit.cs            # Static API entry point
+│   └── Randomization/        # Rng, Xoshiro256
+├── Pragmastat.Demo/          # Demo application
+├── Pragmastat.Tests/         # Unit tests
+└── Pragmastat.TestGenerator/ # Reference test generator
 ```
 
 ## Key Types

--- a/cs/Pragmastat.Tests/Functions/ExpFunctionTests.cs
+++ b/cs/Pragmastat.Tests/Functions/ExpFunctionTests.cs
@@ -75,4 +75,35 @@ public class ExpFunctionTests
     Assert.Equal(FixtureFileCount, testNames.Length);
     Assert.Equal(FixtureArgumentCount, testNames.Sum(name => controller.LoadTestCase(name).Input.Arg.Length));
   }
+
+  /// <summary>
+  /// Both of AdditiveCumulative's range comparisons are false for a NaN, so without an explicit guard it
+  /// leaves the tail branch as a finite 0 or 1: an undefined input answered rather than reported.
+  /// The approximation it replaced propagated NaN, so losing that would be a regression.
+  /// </summary>
+  [Fact]
+  public void AdditiveCumulativeCarriesNaNThroughAndAnswersBothInfinities()
+  {
+    Assert.True(double.IsNaN(AdditiveCumulative.Value(double.NaN)));
+    BitwiseAssert.Equal(1.0, AdditiveCumulative.Value(double.PositiveInfinity), "AdditiveCumulative(+Inf)");
+    BitwiseAssert.Equal(0.0, AdditiveCumulative.Value(double.NegativeInfinity), "AdditiveCumulative(-Inf)");
+    BitwiseAssert.Equal(0.5, AdditiveCumulative.Value(0.0), "AdditiveCumulative(+0)");
+    BitwiseAssert.Equal(0.5, AdditiveCumulative.Value(-0.0), "AdditiveCumulative(-0)");
+  }
+
+  /// <summary>
+  /// The values outside the reduction band, which the shared fixture cannot carry: JSON has no way
+  /// to express an infinity, so the generated suite stops at 709.78 and these arguments are
+  /// covered here or nowhere.
+  /// </summary>
+  [Fact]
+  public void ReturnsTheDeclaredValuesOutsideTheReductionBand()
+  {
+    Assert.True(double.IsNaN(ExpFunction.Value(double.NaN)));
+    BitwiseAssert.Equal(double.PositiveInfinity, ExpFunction.Value(709.8), "ExpFunction(709.8)");
+    BitwiseAssert.Equal(double.PositiveInfinity, ExpFunction.Value(double.PositiveInfinity), "ExpFunction(+Inf)");
+    BitwiseAssert.Equal(0.0, ExpFunction.Value(-745.3), "ExpFunction(-745.3)");
+    BitwiseAssert.Equal(0.0, ExpFunction.Value(double.NegativeInfinity), "ExpFunction(-Inf)");
+    BitwiseAssert.Equal(1.0, ExpFunction.Value(0.0), "ExpFunction(0)");
+  }
 }

--- a/cs/Pragmastat/Functions/AdditiveCumulative.cs
+++ b/cs/Pragmastat/Functions/AdditiveCumulative.cs
@@ -23,6 +23,10 @@ internal static class AdditiveCumulative
   /// <param name="z">-infinity..+infinity</param>
   public static double Value(double z)
   {
+    // NaN satisfies neither comparison below, so without this it would leave the tail branch as a
+    // finite 0 or 1 and an undefined input would be answered rather than reported.
+    if (double.IsNaN(z))
+      return z;
     double t = Abs(z) / Constants.Sqrt2;
     if (t < 0.5)
     {

--- a/cs/Pragmastat/Functions/ExpFunction.cs
+++ b/cs/Pragmastat/Functions/ExpFunction.cs
@@ -88,8 +88,8 @@ internal static class ExpFunction
     // the end. Reconstructing the same sum from the two halves of the reduction keeps them, and
     // costs nothing, being the same operations in a different order. Measured against a 60-digit
     // reference over the band these estimators reach, it halves the worst relative error, from
-    // 2.19e-16 to 1.20e-16, and raises the share of correctly rounded results from 72.6% to
-    // 90.0%. That is where fdlibm sits, which reaches it with a division this does not need.
+    // 2.18e-16 to 1.27e-16, and raises the share of correctly rounded results from 73.6% to
+    // 90.2%. That is a shade better than fdlibm, which reaches 1.30e-16 with a division this does not need.
     double p = 1.0 - ((lo - r * r * q) - hi);
 
     // Two scalings rather than one. Splitting k in half keeps the first factor inside the

--- a/go/AGENTS.md
+++ b/go/AGENTS.md
@@ -16,26 +16,26 @@ mise run go:coverage # Run tests with coverage
 
 ```
 go/
-├── estimators.go              # Public API: Center, Spread, Shift, etc.
-├── assumptions.go             # Input validation and error types
-├── pairwise_margin.go         # Margin calculation for shift bounds
-├── sign_margin.go             # Sign margin for binomial CDF inversion
-├── signed_rank_margin.go      # Signed-rank margin computation
-├── min_misrate.go             # Minimum achievable misrate calculation
-├── additive_cumulative.go            # Standard normal CDF (Chebyshev-fitted erf/erfc)
-├── exp_function.go            # Reproducible exp: range reduction plus fitted polynomial
-├── rng.go                     # Deterministic xoshiro256++ PRNG
-├── xoshiro256.go              # PRNG core implementation
-├── center_impl.go             # O(n log n) Hodges-Lehmann algorithm
-├── center_quantiles_impl.go   # Center quantile binary search
-├── spread_impl.go             # O(n log n) Shamos algorithm
-├── shift_impl.go              # O((m+n) log L) shift quantiles
-├── distribution.go            # Distribution interface
-├── uniform.go                 # Uniform distribution
-├── additive.go                # Additive (Normal/Gaussian) distribution
-├── exp.go                     # Exponential distribution
-├── power.go                   # Power distribution
-├── multiplic.go               # Multiplicative (Log-Normal) distribution
+├── estimators.go            # Public API: Center, Spread, Shift, etc.
+├── assumptions.go           # Input validation and error types
+├── pairwise_margin.go       # Margin calculation for shift bounds
+├── sign_margin.go           # Sign margin for binomial CDF inversion
+├── signed_rank_margin.go    # Signed-rank margin computation
+├── min_misrate.go           # Minimum achievable misrate calculation
+├── additive_cumulative.go   # Standard normal CDF (Chebyshev-fitted erf/erfc)
+├── exp_function.go          # Reproducible exp: range reduction plus fitted polynomial
+├── rng.go                   # Deterministic xoshiro256++ PRNG
+├── xoshiro256.go            # PRNG core implementation
+├── center_impl.go           # O(n log n) Hodges-Lehmann algorithm
+├── center_quantiles_impl.go # Center quantile binary search
+├── spread_impl.go           # O(n log n) Shamos algorithm
+├── shift_impl.go            # O((m+n) log L) shift quantiles
+├── distribution.go          # Distribution interface
+├── uniform.go               # Uniform distribution
+├── additive.go              # Additive (Normal/Gaussian) distribution
+├── exp.go                   # Exponential distribution
+├── power.go                 # Power distribution
+├── multiplic.go             # Multiplicative (Log-Normal) distribution
 ├── demo/
 │   └── main.go                # Demo application
 ├── assume_sorted_test.go      # assume-sorted equivalence

--- a/go/additive_cumulative.go
+++ b/go/additive_cumulative.go
@@ -12,6 +12,12 @@ import "math"
 // the kernels are: the Go compiler fuses a multiply into an add on every FMA-capable target
 // and the other six implementations do not.
 func additiveCumulative(z float64) float64 {
+	// NaN reaches neither Horner chain: both comparisons below are false for it, so without
+	// this the tail branch would return a finite 0 or 1 and the caller would never learn that
+	// an undefined input had been asked about. The function it replaced propagated NaN.
+	if math.IsNaN(z) {
+		return z
+	}
 	t := math.Abs(z) / math.Sqrt2
 	if t < 0.5 {
 		s := float64(t * t)

--- a/go/estimators.go
+++ b/go/estimators.go
@@ -236,7 +236,7 @@ func avgSpread(x, y []float64, assumeSorted bool) (float64, error) {
 		return 0, NewSparityError(SubjectY)
 	}
 
-	return (float64(n*spreadX) + float64(m*spreadY)) / (n + m), nil
+	return normalizeZero((float64(n*spreadX) + float64(m*spreadY)) / (n + m)), nil
 }
 
 // Disparity measures effect size: a normalized difference between x and y.

--- a/go/estimators.go
+++ b/go/estimators.go
@@ -280,7 +280,7 @@ func Disparity(x, y []float64, assumeSorted bool) (float64, error) {
 	}
 	avgSpreadVal := (float64(n*spreadX) + float64(m*spreadY)) / (n + m)
 
-	return shiftVal[0] / avgSpreadVal, nil
+	return normalizeZero(shiftVal[0] / avgSpreadVal), nil
 }
 
 // ShiftBounds provides bounds on the Shift estimator with specified misclassification rate.
@@ -393,11 +393,7 @@ func RatioBounds(x, y []float64, misrate float64, assumeSorted bool) (Bounds, er
 		return Bounds{}, err
 	}
 
-	return Bounds{
-		Lower: math.Exp(logBounds.Lower),
-		Upper: math.Exp(logBounds.Upper),
-		Unit:  NumberUnit,
-	}, nil
+	return newBounds(math.Exp(logBounds.Lower), math.Exp(logBounds.Upper), NumberUnit), nil
 }
 
 // CenterBounds provides exact distribution-free bounds for Center (Hodges-Lehmann pseudomedian).
@@ -645,11 +641,11 @@ func avgSpreadBoundsImpl(x, sortedX, y, sortedY []float64, misrate float64, rngX
 	wx := float64(n) / float64(n+m)
 	wy := float64(m) / float64(n+m)
 
-	return Bounds{
-		Lower: float64(wx*boundsX.Lower) + float64(wy*boundsY.Lower),
-		Upper: float64(wx*boundsX.Upper) + float64(wy*boundsY.Upper),
-		Unit:  NumberUnit,
-	}, nil
+	return newBounds(
+		float64(wx*boundsX.Lower)+float64(wy*boundsY.Lower),
+		float64(wx*boundsX.Upper)+float64(wy*boundsY.Upper),
+		NumberUnit,
+	), nil
 }
 
 func disparityBoundsImpl(x, sortedX, y, sortedY []float64, misrate float64, rngX, rngY *Rng) (Bounds, error) {

--- a/go/exp_function.go
+++ b/go/exp_function.go
@@ -82,8 +82,8 @@ func expFunction(y float64) float64 {
 	// the end. Reconstructing the same sum from the two halves of the reduction keeps them, and
 	// costs nothing, being the same operations in a different order. Measured against a 60-digit
 	// reference over the band these estimators reach, it halves the worst relative error, from
-	// 2.19e-16 to 1.20e-16, and raises the share of correctly rounded results from 72.6% to
-	// 90.0%. That is where fdlibm sits, which reaches it with a division this does not need.
+	// 2.18e-16 to 1.27e-16, and raises the share of correctly rounded results from 73.6% to
+	// 90.2%. That is a shade better than fdlibm, which reaches 1.30e-16 with a division this does not need.
 	p := 1.0 - ((lo - float64(float64(r*r)*q)) - hi)
 
 	// Two scalings rather than one. Splitting k in half keeps the first factor inside the

--- a/go/negative_zero_test.go
+++ b/go/negative_zero_test.go
@@ -133,19 +133,92 @@ func TestBoundsReportPositiveZeros(t *testing.T) {
 	assertPositiveZero(t, centerBounds.Upper, "CenterBounds upper")
 }
 
-// TestNoEstimatorReportsNegativeZero sweeps every public exit, including the ones where a negative
-// zero is currently unreachable. Reachability is what changes when the arithmetic behind an exit
-// changes, so the sweep is the part that keeps holding after such a change.
+// TestEveryReachableExitIsNormalized calls each exit with input that PRODUCES a negative zero when
+// the normalizer is removed. That property is what makes the test worth running: with the fix
+// reverted, every case here fails.
+//
+// The inputs were found by reverting normalizeZero to the identity and searching; they are listed
+// per exit rather than shared, because one sample does not reach a negative zero at every exit.
+// A shared sample was the first version of this test, and it passed with the whole fix reverted:
+// [0, -0, 0, -0, 1, -1] estimates to zero at four exits and the sort leaves a POSITIVE zero in the
+// selected position at all four, so nothing was being asserted.
+func TestEveryReachableExitIsNormalized(t *testing.T) {
+	negZero := math.Copysign(0, -1)
+
+	scalar := []struct {
+		name  string
+		value func() (float64, error)
+	}{
+		{"Center", func() (float64, error) { return Center([]float64{negZero, negZero}, false) }},
+		{"Center/3", func() (float64, error) { return Center([]float64{negZero, negZero, negZero}, false) }},
+		{"Shift", func() (float64, error) { return Shift([]float64{negZero}, []float64{0.0}, false) }},
+		{"Disparity", func() (float64, error) {
+			return Disparity([]float64{negZero, 1.0}, []float64{0.0, 1.0}, false)
+		}},
+	}
+	for _, c := range scalar {
+		value, err := c.value()
+		if err != nil {
+			t.Fatalf("%s: %v", c.name, err)
+		}
+		assertPositiveZero(t, value, c.name)
+	}
+
+	bounded := []struct {
+		name   string
+		bounds func() (Bounds, error)
+	}{
+		{"CenterBounds", func() (Bounds, error) {
+			return CenterBounds([]float64{negZero, negZero, negZero}, 0.3, false)
+		}},
+		{"ShiftBounds", func() (Bounds, error) {
+			return ShiftBounds([]float64{negZero}, []float64{0.0}, 1.0, false)
+		}},
+	}
+	for _, c := range bounded {
+		bounds, err := c.bounds()
+		if err != nil {
+			t.Fatalf("%s: %v", c.name, err)
+		}
+		assertPositiveZero(t, bounds.Lower, c.name+" lower")
+		assertPositiveZero(t, bounds.Upper, c.name+" upper")
+	}
+
+	// The Sample entry points reach the same implementations through a different route, and the
+	// unit-carrying half of the API is where a caller actually meets these values.
+	sample, err := NewSample([]float64{negZero, negZero, negZero})
+	if err != nil {
+		t.Fatalf("NewSample: %v", err)
+	}
+	measurement, err := sample.Center()
+	if err != nil {
+		t.Fatalf("Sample.Center: %v", err)
+	}
+	assertPositiveZero(t, measurement.Value, "Sample.Center")
+
+	sampleBounds, err := sample.CenterBounds(0.3)
+	if err != nil {
+		t.Fatalf("Sample.CenterBounds: %v", err)
+	}
+	assertPositiveZero(t, sampleBounds.Lower, "Sample.CenterBounds lower")
+	assertPositiveZero(t, sampleBounds.Upper, "Sample.CenterBounds upper")
+}
+
+// TestNoEstimatorReportsNegativeZero sweeps the exits where a negative zero is UNREACHABLE today.
+//
+// Spread is an absolute difference, Ratio and RatioBounds are exponentials, the average spread is a
+// weighted sum of two positive quantities: none of them can produce a negative zero as the code
+// stands, so this test cannot fail today and is not asserting the fix. It is here because
+// unreachability is a property of the arithmetic behind each exit, not of the API, and the previous
+// change to that arithmetic is what put a negative zero in Disparity. A proof nobody re-checks is
+// how the next one gets in.
 func TestNoEstimatorReportsNegativeZero(t *testing.T) {
 	scalar := []struct {
 		name  string
 		value func() (float64, error)
 	}{
-		{"Center", func() (float64, error) { return Center(mixedSample, false) }},
 		{"Spread", func() (float64, error) { return Spread(mixedSample, false) }},
-		{"Shift", func() (float64, error) { return Shift(mixedSample, mixedSample, false) }},
 		{"Ratio", func() (float64, error) { return Ratio(positiveSample, positiveSample, false) }},
-		{"Disparity", func() (float64, error) { return Disparity(mixedSample, mixedSample, false) }},
 		{"avgSpread", func() (float64, error) { return avgSpread(mixedSample, mixedSample, false) }},
 	}
 	for _, c := range scalar {
@@ -160,9 +233,7 @@ func TestNoEstimatorReportsNegativeZero(t *testing.T) {
 		name   string
 		bounds func() (Bounds, error)
 	}{
-		{"CenterBounds", func() (Bounds, error) { return CenterBounds(mixedSample, 0.3, false) }},
 		{"SpreadBounds", func() (Bounds, error) { return SpreadBoundsWithSeed(mixedSample, 0.5, "seed", false) }},
-		{"ShiftBounds", func() (Bounds, error) { return ShiftBounds(mixedSample, mixedSample, 0.5, false) }},
 		{"RatioBounds", func() (Bounds, error) { return RatioBounds(positiveSample, positiveSample, 0.5, false) }},
 		{"DisparityBounds", func() (Bounds, error) {
 			return DisparityBoundsWithSeed(mixedSample, mixedSample, 0.9, "seed", false)
@@ -253,9 +324,10 @@ func TestAdditiveCumulativePropagatesNaN(t *testing.T) {
 	}
 }
 
-// TestExpFunctionCutoffs pins the values outside the reduction band, where a language can name
-// its infinity and JSON cannot: the shared fixture stops at 709.78 for that reason, so these
-// arguments are covered here or nowhere.
+// TestExpFunctionCutoffs pins the values a JSON fixture cannot carry: NaN and the two infinities,
+// which have no JSON spelling, and 709.8, which sits past the fixture's last argument of 709.78.
+// The finite arguments below are in the shared fixture as well; they are repeated here so the
+// cutoff behavior reads as one statement rather than two halves in different files.
 func TestExpFunctionCutoffs(t *testing.T) {
 	if !math.IsNaN(expFunction(math.NaN())) {
 		t.Error("expFunction(NaN) should be NaN")

--- a/go/negative_zero_test.go
+++ b/go/negative_zero_test.go
@@ -1,0 +1,272 @@
+package pragmastat
+
+import (
+	"math"
+	"slices"
+	"testing"
+)
+
+// No public estimator reports a negative zero.
+//
+// A sample holding both +0.0 and -0.0 used to make the reported value depend on which of the two
+// the sort happened to leave in the selected position: comparison cannot separate them, so the
+// position was settled by the sorting algorithm rather than by the data, and the seven ports each
+// bring their own sort. Python returned -0.0 for center([0.0, -0.0, 0.0, -0.0, 1.0]) where this
+// port returned +0.0, against an exact conformance class that promises identical bits.
+//
+// Every estimator now sheds the sign on the way out, so these tests compare PAYLOADS. == reads
+// -0.0 and +0.0 as equal, so an equality assertion would pass on exactly the results this file
+// exists to reject; sameFloatBits is the predicate the rest of the suite uses for the same reason.
+//
+// The samples are the ones that reached a negative zero before the fix, plus a sweep that holds
+// the invariant for the estimators where it is currently unreachable. Those are unreachable by
+// proof, not by construction (spread is an absolute difference, ratio is an exponential), and a
+// proof nobody re-checks is how the next divergence gets in. Disparity is here because it was the
+// one exit this port left unwrapped after the other six had been done.
+
+const negativeZeroPayload = 0x8000000000000000
+
+// mixedZeroSamples each estimate to zero, and each selected a -0.0 before the fix.
+var mixedZeroSamples = [][]float64{
+	{0.0, math.Copysign(0, -1), 0.0, math.Copysign(0, -1), 1.0},
+	{math.Copysign(0, -1), math.Copysign(0, -1)},
+	{math.Copysign(0, -1), 0.0},
+	{0.0, math.Copysign(0, -1)},
+	{math.Copysign(0, -1), math.Copysign(0, -1), math.Copysign(0, -1)},
+	{-1.0, 1.0},
+	{-2.0, math.Copysign(0, -1), 2.0},
+}
+
+var (
+	mixedSample    = []float64{0.0, math.Copysign(0, -1), 0.0, math.Copysign(0, -1), 1.0, -1.0}
+	positiveSample = []float64{1.0, 2.0, 3.0, 4.0, 5.0, 6.0}
+)
+
+func assertPositiveZero(t *testing.T, value float64, what string) {
+	t.Helper()
+	if !sameFloatBits(value, 0.0) {
+		t.Errorf("%s = %s, want %s", what, formatFloatBits(value), formatFloatBits(0.0))
+	}
+}
+
+func assertNotNegativeZero(t *testing.T, value float64, what string) {
+	t.Helper()
+	if math.Float64bits(value) == negativeZeroPayload {
+		t.Errorf("%s reported a negative zero: %s", what, formatFloatBits(value))
+	}
+}
+
+func TestCenterReportsPositiveZero(t *testing.T) {
+	for _, x := range mixedZeroSamples {
+		value, err := Center(x, false)
+		if err != nil {
+			t.Fatalf("Center(%v): %v", x, err)
+		}
+		assertPositiveZero(t, value, "Center")
+
+		sample, err := NewSample(x)
+		if err != nil {
+			t.Fatalf("NewSample(%v): %v", x, err)
+		}
+		measurement, err := sample.Center()
+		if err != nil {
+			t.Fatalf("Sample.Center(%v): %v", x, err)
+		}
+		assertPositiveZero(t, measurement.Value, "Sample.Center")
+	}
+}
+
+func TestShiftReportsPositiveZero(t *testing.T) {
+	pairs := [][2][]float64{
+		{{math.Copysign(0, -1)}, {0.0}},
+		{{math.Copysign(0, -1), 1.0}, {0.0, 1.0}},
+		{{math.Copysign(0, -1), math.Copysign(0, -1)}, {0.0, 0.0}},
+	}
+	for _, pair := range pairs {
+		value, err := Shift(pair[0], pair[1], false)
+		if err != nil {
+			t.Fatalf("Shift(%v, %v): %v", pair[0], pair[1], err)
+		}
+		assertPositiveZero(t, value, "Shift")
+	}
+}
+
+func TestDisparityReportsPositiveZero(t *testing.T) {
+	// Shift selects the -0.0 difference; the average spread is positive, so the sign survived.
+	x := []float64{math.Copysign(0, -1), 1.0}
+	y := []float64{0.0, 1.0}
+	value, err := Disparity(x, y, false)
+	if err != nil {
+		t.Fatalf("Disparity: %v", err)
+	}
+	assertPositiveZero(t, value, "Disparity")
+
+	sx, err := NewSample(x)
+	if err != nil {
+		t.Fatalf("NewSample(x): %v", err)
+	}
+	sy, err := NewSample(y)
+	if err != nil {
+		t.Fatalf("NewSample(y): %v", err)
+	}
+	measurement, err := sx.Disparity(sy)
+	if err != nil {
+		t.Fatalf("Sample.Disparity: %v", err)
+	}
+	assertPositiveZero(t, measurement.Value, "Sample.Disparity")
+}
+
+func TestBoundsReportPositiveZeros(t *testing.T) {
+	// A single pair takes the degenerate x[0] - y[0] path, where -0.0 - +0.0 is -0.0.
+	bounds, err := ShiftBounds([]float64{math.Copysign(0, -1)}, []float64{0.0}, 1.0, false)
+	if err != nil {
+		t.Fatalf("ShiftBounds: %v", err)
+	}
+	assertPositiveZero(t, bounds.Lower, "ShiftBounds lower")
+	assertPositiveZero(t, bounds.Upper, "ShiftBounds upper")
+
+	centerBounds, err := CenterBounds(mixedSample, 0.3, false)
+	if err != nil {
+		t.Fatalf("CenterBounds: %v", err)
+	}
+	assertPositiveZero(t, centerBounds.Lower, "CenterBounds lower")
+	assertPositiveZero(t, centerBounds.Upper, "CenterBounds upper")
+}
+
+// TestNoEstimatorReportsNegativeZero sweeps every public exit, including the ones where a negative
+// zero is currently unreachable. Reachability is what changes when the arithmetic behind an exit
+// changes, so the sweep is the part that keeps holding after such a change.
+func TestNoEstimatorReportsNegativeZero(t *testing.T) {
+	scalar := []struct {
+		name  string
+		value func() (float64, error)
+	}{
+		{"Center", func() (float64, error) { return Center(mixedSample, false) }},
+		{"Spread", func() (float64, error) { return Spread(mixedSample, false) }},
+		{"Shift", func() (float64, error) { return Shift(mixedSample, mixedSample, false) }},
+		{"Ratio", func() (float64, error) { return Ratio(positiveSample, positiveSample, false) }},
+		{"Disparity", func() (float64, error) { return Disparity(mixedSample, mixedSample, false) }},
+		{"avgSpread", func() (float64, error) { return avgSpread(mixedSample, mixedSample, false) }},
+	}
+	for _, c := range scalar {
+		value, err := c.value()
+		if err != nil {
+			t.Fatalf("%s: %v", c.name, err)
+		}
+		assertNotNegativeZero(t, value, c.name)
+	}
+
+	bounded := []struct {
+		name   string
+		bounds func() (Bounds, error)
+	}{
+		{"CenterBounds", func() (Bounds, error) { return CenterBounds(mixedSample, 0.3, false) }},
+		{"SpreadBounds", func() (Bounds, error) { return SpreadBoundsWithSeed(mixedSample, 0.5, "seed", false) }},
+		{"ShiftBounds", func() (Bounds, error) { return ShiftBounds(mixedSample, mixedSample, 0.5, false) }},
+		{"RatioBounds", func() (Bounds, error) { return RatioBounds(positiveSample, positiveSample, 0.5, false) }},
+		{"DisparityBounds", func() (Bounds, error) {
+			return DisparityBoundsWithSeed(mixedSample, mixedSample, 0.9, "seed", false)
+		}},
+		{"avgSpreadBounds", func() (Bounds, error) {
+			sorted := append([]float64(nil), mixedSample...)
+			slices.Sort(sorted)
+			return avgSpreadBoundsImpl(mixedSample, sorted, mixedSample, sorted, 0.9,
+				NewRngFromString("seed"), NewRngFromString("seed"))
+		}},
+	}
+	for _, c := range bounded {
+		bounds, err := c.bounds()
+		if err != nil {
+			t.Fatalf("%s: %v", c.name, err)
+		}
+		assertNotNegativeZero(t, bounds.Lower, c.name+" lower")
+		assertNotNegativeZero(t, bounds.Upper, c.name+" upper")
+	}
+}
+
+func TestInputsKeepTheirNegativeZeros(t *testing.T) {
+	// Only outputs are normalized: a sample must still be able to CONTAIN a -0.0.
+	x := []float64{0.0, math.Copysign(0, -1), 0.0, math.Copysign(0, -1), 1.0}
+	if _, err := Center(x, false); err != nil {
+		t.Fatalf("Center: %v", err)
+	}
+	if math.Float64bits(x[1]) != negativeZeroPayload {
+		t.Errorf("input was rewritten: %s", formatFloatBits(x[1]))
+	}
+
+	sample, err := NewSample(x)
+	if err != nil {
+		t.Fatalf("NewSample: %v", err)
+	}
+	if _, err := sample.Center(); err != nil {
+		t.Fatalf("Sample.Center: %v", err)
+	}
+	for _, v := range sample.cachedSortedValues() {
+		if math.Float64bits(v) == negativeZeroPayload {
+			return
+		}
+	}
+	t.Error("sorted values were rewritten: no negative zero left in the sample")
+}
+
+func TestNormalizeZeroLeavesEveryNonZeroAlone(t *testing.T) {
+	values := []float64{1.0, -1.0, 1e-320, -1e-320, math.Inf(1), math.Inf(-1), math.NaN(), 5e-324, -5e-324}
+	for _, v := range values {
+		if !sameFloatBits(normalizeZero(v), v) {
+			t.Errorf("normalizeZero(%s) = %s", formatFloatBits(v), formatFloatBits(normalizeZero(v)))
+		}
+	}
+}
+
+func TestNormalizeZeroMapsBothZerosToThePositiveOne(t *testing.T) {
+	for _, v := range []float64{0.0, math.Copysign(0, -1)} {
+		assertPositiveZero(t, normalizeZero(v), "normalizeZero")
+	}
+}
+
+func TestNewBoundsNormalizesBothEndpoints(t *testing.T) {
+	bounds := newBounds(math.Copysign(0, -1), math.Copysign(0, -1), NumberUnit)
+	assertPositiveZero(t, bounds.Lower, "lower")
+	assertPositiveZero(t, bounds.Upper, "upper")
+
+	infinite := newBounds(math.Inf(-1), math.Inf(1), NumberUnit)
+	if !sameFloatBits(infinite.Lower, math.Inf(-1)) || !sameFloatBits(infinite.Upper, math.Inf(1)) {
+		t.Error("newBounds rewrote an infinite endpoint")
+	}
+}
+
+// TestAdditiveCumulativePropagatesNaN pins the one input for which the function has no answer. Both of
+// its range comparisons are false for a NaN, so without the guard it leaves the tail branch as a
+// finite 0 or 1: an undefined input answered rather than reported.
+func TestAdditiveCumulativePropagatesNaN(t *testing.T) {
+	if !math.IsNaN(additiveCumulative(math.NaN())) {
+		t.Errorf("additiveCumulative(NaN) = %s, want NaN", formatFloatBits(additiveCumulative(math.NaN())))
+	}
+	if !sameFloatBits(additiveCumulative(math.Inf(1)), 1.0) {
+		t.Errorf("additiveCumulative(+Inf) = %s, want 1", formatFloatBits(additiveCumulative(math.Inf(1))))
+	}
+	if !sameFloatBits(additiveCumulative(math.Inf(-1)), 0.0) {
+		t.Errorf("additiveCumulative(-Inf) = %s, want 0", formatFloatBits(additiveCumulative(math.Inf(-1))))
+	}
+	if !sameFloatBits(additiveCumulative(0.0), 0.5) || !sameFloatBits(additiveCumulative(math.Copysign(0, -1)), 0.5) {
+		t.Error("additiveCumulative disagreed with itself on the two zeros")
+	}
+}
+
+// TestExpFunctionCutoffs pins the values outside the reduction band, where a language can name
+// its infinity and JSON cannot: the shared fixture stops at 709.78 for that reason, so these
+// arguments are covered here or nowhere.
+func TestExpFunctionCutoffs(t *testing.T) {
+	if !math.IsNaN(expFunction(math.NaN())) {
+		t.Error("expFunction(NaN) should be NaN")
+	}
+	if !math.IsInf(expFunction(709.8), 1) || !math.IsInf(expFunction(math.Inf(1)), 1) {
+		t.Error("expFunction should overflow to +Inf above the cutoff")
+	}
+	if !sameFloatBits(expFunction(-745.3), 0.0) || !sameFloatBits(expFunction(math.Inf(-1)), 0.0) {
+		t.Error("expFunction should underflow to +0 below the cutoff")
+	}
+	if !sameFloatBits(expFunction(0.0), 1.0) {
+		t.Error("expFunction(0) should be exactly 1")
+	}
+}

--- a/kt/AGENTS.md
+++ b/kt/AGENTS.md
@@ -16,27 +16,27 @@ mise run kt:pack     # Create JAR package
 ```
 kt/
 ├── src/main/kotlin/dev/pragmastat/
-│   ├── Estimators.kt            # Raw List-based API: center, spread, shift, etc.
-│   ├── Sample.kt                # Typed Sample API: unit-aware overloads
-│   ├── Measurement.kt           # Value + MeasurementUnit pair
-│   ├── MeasurementUnit.kt       # Unit identity, family, conversion
-│   ├── UnitRegistry.kt          # MeasurementUnit lookup by id
-│   ├── Probability.kt           # Typed [0, 1] wrapper for misrate parameters
-│   ├── Compare.kt               # compare1/compare2 threshold-verdict API
-│   ├── Assumptions.kt           # Input validation and error types
-│   ├── PairwiseMargin.kt        # Margin calculation for shift bounds (internal)
-│   ├── SignMargin.kt            # Sign margin for binomial CDF inversion
-│   ├── SignedRankMargin.kt      # Signed-rank margin computation
-│   ├── MinMisrate.kt            # Minimum achievable misrate calculation
-│   ├── AdditiveCumulative.kt           # Standard normal CDF (Chebyshev-fitted erf/erfc)
-│   ├── ExpFunction.kt           # Reproducible exp: range reduction plus fitted polynomial
-│   ├── Rng.kt                   # Deterministic xoshiro256++ PRNG
-│   ├── Xoshiro256.kt            # PRNG core implementation
-│   ├── CenterImpl.kt            # O(n log n) Hodges-Lehmann algorithm
-│   ├── CenterQuantilesImpl.kt   # Center quantile binary search
-│   ├── SpreadImpl.kt            # O(n log n) Shamos algorithm
-│   ├── ShiftImpl.kt             # O((m+n) log L) shift quantiles
-│   ├── Constants.kt             # Internal constants
+│   ├── Estimators.kt          # Raw List-based API: center, spread, shift, etc.
+│   ├── Sample.kt              # Typed Sample API: unit-aware overloads
+│   ├── Measurement.kt         # Value + MeasurementUnit pair
+│   ├── MeasurementUnit.kt     # Unit identity, family, conversion
+│   ├── UnitRegistry.kt        # MeasurementUnit lookup by id
+│   ├── Probability.kt         # Typed [0, 1] wrapper for misrate parameters
+│   ├── Compare.kt             # compare1/compare2 threshold-verdict API
+│   ├── Assumptions.kt         # Input validation and error types
+│   ├── PairwiseMargin.kt      # Margin calculation for shift bounds (internal)
+│   ├── SignMargin.kt          # Sign margin for binomial CDF inversion
+│   ├── SignedRankMargin.kt    # Signed-rank margin computation
+│   ├── MinMisrate.kt          # Minimum achievable misrate calculation
+│   ├── AdditiveCumulative.kt  # Standard normal CDF (Chebyshev-fitted erf/erfc)
+│   ├── ExpFunction.kt         # Reproducible exp: range reduction plus fitted polynomial
+│   ├── Rng.kt                 # Deterministic xoshiro256++ PRNG
+│   ├── Xoshiro256.kt          # PRNG core implementation
+│   ├── CenterImpl.kt          # O(n log n) Hodges-Lehmann algorithm
+│   ├── CenterQuantilesImpl.kt # Center quantile binary search
+│   ├── SpreadImpl.kt          # O(n log n) Shamos algorithm
+│   ├── ShiftImpl.kt           # O((m+n) log L) shift quantiles
+│   ├── Constants.kt           # Internal constants
 │   └── distributions/
 │       ├── Distribution.kt
 │       ├── Uniform.kt
@@ -45,19 +45,19 @@ kt/
 │       ├── Power.kt
 │       └── Multiplic.kt
 ├── src/test/kotlin/dev/pragmastat/
-│   ├── BitwiseAssert.kt                   # Raw-payload equality: the one exact comparison
-│   ├── ReferenceTest.kt                   # JSON fixture validation
-│   ├── MetrologyTest.kt                   # JSON fixtures for the unit/metrology system
-│   ├── InvarianceTest.kt                  # Mathematical property tests
-│   ├── AssumeSortedTest.kt                # Raw-API assumeSorted=true branch coverage
-│   ├── MutationTest.kt                    # Estimators must not mutate caller lists
-│   ├── CenterMidpointSymmetryTest.kt      # n==2 midpoint exact order symmetry
-│   ├── NegativeZeroTest.kt                # No estimator reports a negative zero
-│   ├── BoundsUnitTest.kt                  # Bounds unit propagation (Sample vs raw)
-│   ├── ProbabilityTest.kt                 # Probability [0, 1] range validation
-│   ├── RawMisrateDomainTest.kt            # Raw-API misrate domain errors
-│   ├── RatioBoundsErrorPriorityTest.kt    # domain-before-positivity error priority
-│   └── PerformanceTest.kt                 # Wall-clock sanity checks on large inputs
+│   ├── BitwiseAssert.kt                # Raw-payload equality: the one exact comparison
+│   ├── ReferenceTest.kt                # JSON fixture validation
+│   ├── MetrologyTest.kt                # JSON fixtures for the unit/metrology system
+│   ├── InvarianceTest.kt               # Mathematical property tests
+│   ├── AssumeSortedTest.kt             # Raw-API assumeSorted=true branch coverage
+│   ├── MutationTest.kt                 # Estimators must not mutate caller lists
+│   ├── CenterMidpointSymmetryTest.kt   # n==2 midpoint exact order symmetry
+│   ├── NegativeZeroTest.kt             # No estimator reports a negative zero
+│   ├── BoundsUnitTest.kt               # Bounds unit propagation (Sample vs raw)
+│   ├── ProbabilityTest.kt              # Probability [0, 1] range validation
+│   ├── RawMisrateDomainTest.kt         # Raw-API misrate domain errors
+│   ├── RatioBoundsErrorPriorityTest.kt # domain-before-positivity error priority
+│   └── PerformanceTest.kt              # Wall-clock sanity checks on large inputs
 └── build.gradle.kts
 ```
 

--- a/kt/build.gradle.kts
+++ b/kt/build.gradle.kts
@@ -30,6 +30,21 @@ testing {
     }
 }
 
+// The reference fixtures live outside this project, in the repository-wide tests/ directory, and
+// the suites read them at runtime. Gradle keys its up-to-date check on declared inputs, so
+// without this an edited fixture leaves the previous PASSED result in place and `gradlew test`
+// reports success in under a second without running anything. Verified by truncating a fixture:
+// the run stayed green until these lines existed.
+//
+// This is the same defect the Go port had, where the answer was -count=1. Declaring the input is
+// the better shape here: the cache keeps working and starts telling the truth.
+tasks.withType<Test>().configureEach {
+    inputs
+        .dir(rootProject.layout.projectDirectory.dir("../tests"))
+        .withPropertyName("referenceFixtures")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+}
+
 kotlin {
     jvmToolchain(11)
     sourceSets {

--- a/kt/src/main/kotlin/dev/pragmastat/AdditiveCumulative.kt
+++ b/kt/src/main/kotlin/dev/pragmastat/AdditiveCumulative.kt
@@ -18,6 +18,11 @@ import kotlin.math.sqrt
  * @return Area under the Standard Normal Curve from -infinity to x
  */
 internal fun additiveCumulative(z: Double): Double {
+    // NaN satisfies neither comparison below, so without this it would leave the tail branch as a
+    // finite 0 or 1 and an undefined input would be answered rather than reported.
+    if (z.isNaN()) {
+        return z
+    }
     val t = abs(z) / sqrt(2.0)
     if (t < 0.5) {
         val s = t * t

--- a/kt/src/main/kotlin/dev/pragmastat/ExpFunction.kt
+++ b/kt/src/main/kotlin/dev/pragmastat/ExpFunction.kt
@@ -85,8 +85,8 @@ internal fun expFunction(y: Double): Double {
     // the end. Reconstructing the same sum from the two halves of the reduction keeps them, and
     // costs nothing, being the same operations in a different order. Measured against a 60-digit
     // reference over the band these estimators reach, it halves the worst relative error, from
-    // 2.19e-16 to 1.20e-16, and raises the share of correctly rounded results from 72.6% to
-    // 90.0%. That is where fdlibm sits, which reaches it with a division this does not need.
+    // 2.18e-16 to 1.27e-16, and raises the share of correctly rounded results from 73.6% to
+    // 90.2%. That is a shade better than fdlibm, which reaches 1.30e-16 with a division this does not need.
     val p = 1.0 - ((lo - r * r * q) - hi)
 
     // Two scalings rather than one. Splitting k in half keeps the first factor inside the

--- a/kt/src/test/kotlin/dev/pragmastat/AdditiveCumulativeTest.kt
+++ b/kt/src/test/kotlin/dev/pragmastat/AdditiveCumulativeTest.kt
@@ -1,0 +1,39 @@
+package dev.pragmastat
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * [additiveCumulative] has no answer for a NaN, and both of its range comparisons are false for one, so
+ * without an explicit guard it leaves the tail branch as a finite 0 or 1: an undefined input
+ * answered rather than reported. The approximation it replaced propagated NaN, so losing that
+ * would be a regression on behavior every port shares.
+ *
+ * The assertions compare PAYLOADS. `==` reads the two zeros as equal and every NaN as unequal,
+ * neither of which is the claim being made here.
+ */
+class AdditiveCumulativeTest {
+    @Test
+    fun carriesNaNThroughAndAnswersBothInfinities() {
+        assertTrue(additiveCumulative(Double.NaN).isNaN(), "additiveCumulative(NaN) should be NaN")
+        assertBitwise(1.0, additiveCumulative(Double.POSITIVE_INFINITY), "additiveCumulative(+Inf)")
+        assertBitwise(0.0, additiveCumulative(Double.NEGATIVE_INFINITY), "additiveCumulative(-Inf)")
+        assertBitwise(0.5, additiveCumulative(0.0), "additiveCumulative(+0)")
+        assertBitwise(0.5, additiveCumulative(-0.0), "additiveCumulative(-0)")
+    }
+
+    /**
+     * The values outside the reduction band, which the shared fixture cannot carry: JSON has no
+     * way to express an infinity, so the generated suite stops at 709.78 and these arguments are
+     * covered here or nowhere.
+     */
+    @Test
+    fun expFunctionReturnsTheDeclaredValuesOutsideTheReductionBand() {
+        assertTrue(expFunction(Double.NaN).isNaN(), "expFunction(NaN) should be NaN")
+        assertBitwise(Double.POSITIVE_INFINITY, expFunction(709.8), "expFunction(709.8)")
+        assertBitwise(Double.POSITIVE_INFINITY, expFunction(Double.POSITIVE_INFINITY), "expFunction(+Inf)")
+        assertBitwise(0.0, expFunction(-745.3), "expFunction(-745.3)")
+        assertBitwise(0.0, expFunction(Double.NEGATIVE_INFINITY), "expFunction(-Inf)")
+        assertBitwise(1.0, expFunction(0.0), "expFunction(0)")
+    }
+}

--- a/kt/src/test/kotlin/dev/pragmastat/ReferenceTest.kt
+++ b/kt/src/test/kotlin/dev/pragmastat/ReferenceTest.kt
@@ -135,6 +135,13 @@ class ReferenceTest {
     private val mapper = ObjectMapper().registerModule(KotlinModule.Builder().build())
     private val epsilon = 1e-9
 
+    private companion object {
+        // The size of the generated exp-function fixture: 1032 arguments over four files. Pinned
+        // rather than counted from the directory, because counting the directory and asserting
+        // the count matches it asserts nothing.
+        const val EXP_FUNCTION_ARGUMENT_COUNT = 1032
+    }
+
     /**
      * Create the y-argument sample for the Sample-based two-sample path.
      *
@@ -1739,7 +1746,15 @@ class ReferenceTest {
                     found.containsAll(expectedFiles),
                     "Expected exp-function fixtures $expectedFiles but found $found",
                 )
-                assertTrue(total > 0, "exp-function fixtures carry no arguments")
+                // The argument count is pinned, not merely required to be positive. A file that
+                // keeps its name and loses its contents satisfies both assertions above, and the
+                // other six ports pin this number, so a truncated fixture would show up as this
+                // port alone still passing.
+                assertEquals(
+                    EXP_FUNCTION_ARGUMENT_COUNT,
+                    total,
+                    "exp-function: loaded $total arguments, expected $EXP_FUNCTION_ARGUMENT_COUNT",
+                )
             },
         )
 

--- a/manual/additive-cumulative/additive-cumulative-algorithm.typ
+++ b/manual/additive-cumulative/additive-cumulative-algorithm.typ
@@ -47,10 +47,19 @@ The truncated quantity there is $"erfc"(4.3) \/ 2 approx 6 dot 10^(-10)$, so the
   merely imprecise beyond that point: it is wrong by a relative error of $1$, as any approximation
   that stops is.
 
-The cutoff is placed where no estimator reaches rather than where the truncated value becomes
-  negligible, and the accuracy claim below is scoped to $abs(z) <= 6$ for the same reason.
-Both margins evaluate this function on a standardized statistic whose magnitude stays far inside
-  that range for every sample size the Edgeworth branches serve.
+The cutoff is reachable, and the accuracy claim below is scoped to $abs(z) <= 6$ for that reason.
+Both margins search their whole support on every call, so both evaluate this function past the
+  cutoff routinely; what matters is whether the returned index lands there.
+It does once the requested misrate falls far enough into the tail that every candidate the search
+  compares is answered with the same $0$, at which point the returned margin stops changing.
+How far is a function of the sample size, since the reachable range of the statistic grows with it:
+  just past the exact branches, at $n = 201$ and $m = 200$, the margin stops moving below about
+  $10^(-10)$, while at $n = m = 500$ it is still moving at $10^(-158)$.
+The approximation this replaced saturated one decade earlier on the first of those, at about
+  $10^(-9)$, so replacing it moved the boundary without removing it.
+Below that point the delivered misrate is the one the plateau implies rather than the one asked
+  for, and nothing says so: the exact branches reject a misrate under their own floor, and the
+  Edgeworth branches have no equivalent.
 
 *Origin of the coefficients*
 

--- a/manual/additive-cumulative/additive-cumulative-notes.typ
+++ b/manual/additive-cumulative/additive-cumulative-notes.typ
@@ -27,8 +27,11 @@ That approximation is short and requires no library calls, which is why it was c
 
 Its accuracy was assessed twice in print soon after publication (@pike1964, @hill1967), the second
   time alongside six other algorithms for the same function.
-Measured here against a reference accurate to 36 digits, its worst relative error reaches
-  $4.5 dot 10^(-7)$ near the center, where the margins spend most of their evaluations.
+Measured here against a reference accurate to 36 digits, its relative error grows with distance
+  from the center: $6 dot 10^(-10)$ within one spread, $4.5 dot 10^(-7)$ at three, $4.7 dot
+  10^(-4)$ at five, and exactly $1$ past six, where it returns zero.
+The margins spend most of their evaluations near the center, but the answer is decided in the
+  tail, which is where the approximation is weakest.
 That gap reaches the returned value rather than remaining beneath it.
 Recomputing the margins over the Edgeworth region with an accurate distribution function changes
   13 of 2961 of them, so on roughly $0.4%$ of those inputs all seven implementations agreed on an

--- a/manual/additive-cumulative/additive-cumulative.typ
+++ b/manual/additive-cumulative/additive-cumulative.typ
@@ -37,9 +37,13 @@ The distribution function of the standard $Additive$ ('Normal') distribution.
 *Properties*
 
 #list(marker: none, tight: true,
-  [*Reflection* #h(2em) $AdditiveCumulative(-z) = 1 - AdditiveCumulative(z)$],
+  [*Reflection* #h(2em) $AdditiveCumulative(-z) = 1 - AdditiveCumulative(z)$ to within $6 dot 10^(-17)$ in
+    absolute terms. The two sides are not interchangeable: past the center $1 - AdditiveCumulative(z)$
+    loses most of its significant digits to cancellation, which is why the tail is computed from
+    $"erfc"$ rather than by subtraction],
   [*Bounds* #h(2em) $0 <= AdditiveCumulative(z) <= 1$],
-  [*Monotonicity* #h(2em) non-decreasing in $z$],
+  [*Monotonicity* #h(2em) non-decreasing in $z$ to within two units in the last place; adjacent
+    representable arguments invert by at most that much, inside the central chain],
   [*Center* #h(2em) $AdditiveCumulative(0) = 1 \/ 2$ exactly],
 )
 

--- a/manual/additive-cumulative/additive-cumulative.typ
+++ b/manual/additive-cumulative/additive-cumulative.typ
@@ -37,10 +37,10 @@ The distribution function of the standard $Additive$ ('Normal') distribution.
 *Properties*
 
 #list(marker: none, tight: true,
-  [*Reflection* #h(2em) $AdditiveCumulative(-z) = 1 - AdditiveCumulative(z)$ to within $6 dot 10^(-17)$ in
-    absolute terms. The two sides are not interchangeable: past the center $1 - AdditiveCumulative(z)$
-    loses most of its significant digits to cancellation, which is why the tail is computed from
-    $"erfc"$ rather than by subtraction],
+  [*Reflection* #h(2em) $AdditiveCumulative(-z) = 1 - AdditiveCumulative(z)$ to within
+    $6 dot 10^(-17)$ in absolute terms. The two sides are not interchangeable: past the center
+    $1 - AdditiveCumulative(z)$ loses most of its significant digits to cancellation, which is why
+    the tail is computed from $"erfc"$ rather than by subtraction],
   [*Bounds* #h(2em) $0 <= AdditiveCumulative(z) <= 1$],
   [*Monotonicity* #h(2em) non-decreasing in $z$ to within two units in the last place; adjacent
     representable arguments invert by at most that much, inside the central chain],

--- a/manual/exp-function/exp-function-algorithm.typ
+++ b/manual/exp-function/exp-function-algorithm.typ
@@ -62,9 +62,10 @@ Reconstructing the sum from the two halves preserves them: $"hi"$ is exact, and 
   term $r^2 Q(r)$ is exposed to the rounded $r$.
 
 This single line accounts for most of the accuracy the function achieves.
-Measured against a sixty-digit reference, it reduces the worst relative error from
-  $2.19 dot 10^(-16)$ to $1.30 dot 10^(-16)$ and raises the share of correctly rounded results from
-  $72.6%$ to $90.0%$, at no cost: the same operations in a different order.
+Measured against a sixty-digit reference over the same band as the table in the notes, it reduces
+  the worst relative error from $2.18 dot 10^(-16)$ to $1.27 dot 10^(-16)$ and raises the share of
+  correctly rounded results from $73.6%$ to $90.2%$, at no cost: the same operations in a different
+  order.
 
 *The scaling proceeds in two steps*
 

--- a/manual/exp-function/exp-function-notes.typ
+++ b/manual/exp-function/exp-function-notes.typ
@@ -80,9 +80,11 @@ The TypeScript runtime replaced its exponential outright during the preparation 
 *Accuracy relative to the alternatives*
 
 Writing a function does not make it better than the ones written by specialists.
-Each row below reports the worst relative error over the band these estimators reach, measured
-  against a sixty-digit reference, together with the share of arguments where the result is the
-  correctly rounded double.
+Each row below reports the worst relative error over $-40 <= y <= 0$, the band these estimators
+  reach, measured against a sixty-digit reference on a uniform grid of 200001 arguments, together
+  with the share of those arguments where the result is the correctly rounded double.
+Every row was measured in one run on one machine, so the rows are comparable to each other; the
+  absolute figures depend on the grid.
 
 #table(
   columns: 3,
@@ -92,15 +94,17 @@ Each row below reports the worst relative error over the band these estimators r
   [*Implementation*], [*Worst relative error*], [*Correctly rounded*],
   table.hline(),
   [Table-based system library], [$1.11 dot 10^(-16)$], [$99.9%$],
-  [Table-based vendor library], [$1.11 dot 10^(-16)$], [$99.7%$],
-  [$ExpFunction$], [$1.30 dot 10^(-16)$], [$90.0%$],
-  [1993 reference code], [$1.30 dot 10^(-16)$], [$90.0%$],
-  [One language runtime], [$2.55 dot 10^(-16)$], [$86.4%$],
+  [$ExpFunction$], [$1.27 dot 10^(-16)$], [$90.2%$],
+  [1993 reference code], [$1.30 dot 10^(-16)$], [$90.2%$],
+  [One language runtime], [$2.42 dot 10^(-16)$], [$86.5%$],
   table.hline(),
 )
 
-The function places third of five, matching the long-standing reference implementation that two of
-  the runtimes descend from and exceeding one of the runtimes it replaces.
+The function places second of four: behind the table-based library the system provides, a little
+  ahead of the long-standing reference implementation that two of the runtimes descend from, and
+  well ahead of one of the runtimes it replaces.
+The table-based library reaches its accuracy with a lookup table this deliberately does not have,
+  since a table is one more thing seven implementations would have to agree on bit for bit.
 
 Two qualifications bound what those figures mean.
 The tabulated errors are maxima over a uniform grid; searching the same range adversarially raises

--- a/manual/exp-function/exp-function-tests.typ
+++ b/manual/exp-function/exp-function-tests.typ
@@ -18,7 +18,10 @@ All seven implementations compare the results by binary64 payload rather than by
 
 *Finite range* — 401 points over $[-745, 709]$:
 
-- Spans the largest finite result down through the subnormal range to the smallest denormal.
+- Reaches from $8.2 dot 10^307$ down through the subnormal range to the smallest denormal, so 11
+  of the 401 results are subnormal and the last one is the smallest positive double there is.
+  The grid stops short of the overflow cutoff on purpose: the largest finite result, $1.79 dot
+  10^308$ at $y = 709.78$, is in the boundaries file, where the values that decide behavior belong.
 
 *Boundaries* — 29 points at the values where the construction changes behavior:
 
@@ -27,9 +30,8 @@ All seven implementations compare the results by binary64 payload rather than by
 - The first denormals, and both signed zeros
 
 Arguments above $709.78$ are absent because their result is infinite and JSON provides no way to
-  express one.
-Each implementation keeps its own unit test for the overflow cutoff, where a language can name its
-  infinity.
+  express one, and neither NaN nor the two infinities can appear as arguments for the same reason.
+Each implementation keeps its own unit test for those, where a language can name its own infinity.
 
 *Why this suite exists separately*
 
@@ -54,8 +56,15 @@ Both compare it against a construction that cannot be wrong, across every expone
 *Monotonicity*.
 Both margins binary-search an expansion under the assumption that it is monotone in the index,
   which rests on this function being monotone.
-A single inversion would allow the search to return either neighbor.
-No inversion has been found.
+A single inversion would allow the search to return either neighbor, and the two neighbors are
+  different confidence bounds.
+The sweep walks adjacent representable arguments rather than a grid, since an inversion between
+  two neighbors is exactly what the search can hit and a grid steps over it; 180000 of them across
+  nine bands produce none.
+One port runs it: all seven return identical bits on every argument, which this suite is what
+  pins, so a property measured in one holds in all.
+The distribution function above does not have this property to the same strength, and the
+  expansion the pairwise search bisects inverts by up to one unit in the last place.
 
 *That the fixture is actually compared*.
 A fixture loader that finds no files reports success.

--- a/manual/methodology/methodology.typ
+++ b/manual/methodology/methodology.typ
@@ -496,8 +496,9 @@ The $Additive$ ('Normal') distribution function inside the Edgeworth branches of
   used to be ACM
   Algorithm 209, a polynomial evaluated identically by all seven.
 It was chosen for being identical, not for being close, and it was not close: measured against a
-  reference good to thirty-six digits, its worst relative error is $4.5 dot 10^(-7)$ near the
-  center, and past $abs(z) = 6$ it returns exactly zero, a relative error of $1$.
+  reference good to thirty-six digits, its relative error grows with distance from the center,
+  from $6 dot 10^(-10)$ within one spread to $4.5 dot 10^(-7)$ at three and $4.7 dot 10^(-4)$ at
+  five, and past $abs(z) = 6$ it returns exactly zero, a relative error of $1$.
 That gap reached the answer rather than staying under it.
 Recomputing the margins over the Edgeworth region with an accurate distribution function changes
   13 of 2961 of them, so on about $0.4%$ of those inputs all seven agreed on an integer that was
@@ -546,7 +547,7 @@ What that costs in accuracy is worth stating plainly, because owning a function 
   better than the ones written by people who do it for a living.
 Measured against a sixty-digit reference over the range these estimators reach, it has a worst
   relative error of $1.3 dot 10^(-16)$ and returns the correctly rounded result on 90% of inputs.
-The best platform libraries are better, at $1.1 dot 10^(-16)$ and 99.9%.
+The table-based library the system provides is better, at $1.1 dot 10^(-16)$ and 99.9%.
 No implementation measured here, the toolkit's included, is ever more than one unit in the last
   place from the correctly rounded value, so the whole spread is one bit wide.
 Being within a bit of every library and identical to itself everywhere is the trade, and it is the

--- a/mise.toml
+++ b/mise.toml
@@ -159,8 +159,19 @@ set -euo pipefail
 cache="$(mktemp -d)"
 trap 'rm -rf "$cache"' EXIT
 for arch in arm64 ppc64le s390x riscv64; do
-  fused="$(GOCACHE="$cache/$arch" GOARCH="$arch" go build -gcflags=-S ./... 2>&1 \\
-    | grep -E 'FMADD|FMSUB|FNMADD|FNMSUB' || true)"
+  # The assembly has to be captured separately from the grep. Piping the build straight into
+  # grep hides its exit status, so a cross-compile that fails prints no assembly, matches no
+  # pattern, and reports success: the guard turns into a no-op exactly when it stops working.
+  if ! asm="$(GOCACHE="$cache/$arch" GOARCH="$arch" go build -gcflags=-S ./... 2>&1)"; then
+    echo "ERROR: cross-compile for $arch failed, so nothing was inspected:" >&2
+    echo "$asm" >&2
+    exit 1
+  fi
+  if [ -z "$asm" ]; then
+    echo "ERROR: cross-compile for $arch produced no assembly to inspect." >&2
+    exit 1
+  fi
+  fused="$(printf '%s' "$asm" | grep -E 'FMADD|FMSUB|FNMADD|FNMSUB' || true)"
   if [ -n "$fused" ]; then
     echo "ERROR: FMA contraction on $arch:" >&2
     echo "$fused" >&2
@@ -617,6 +628,15 @@ qemu-aarch64-static "$binary" -test.count=1
 echo "the Go suite agrees with the fixtures on arm64"
 """
 
+[tasks."tests:check:coefficients"]
+description = "Assert the shipped coefficients still match the scripts that produce them"
+# The manual calls the coefficients "reproducible rather than transcribed" and names the two fit
+# scripts as their source, but nothing ran either script: they printed and exited, and the
+# constants sit as literals in seven files. This runs both, compares every coefficient as a
+# payload against all seven ports, and runs the reference oracle's own self-check, which had been
+# given a failing exit status that nothing invoked.
+run = "python3 tests/check_coefficients.py ."
+
 [tasks."tests:check:spelling"]
 description = "Assert prose across the repository uses one spelling convention"
 # Every port and the manual are written in American English, and main held 169 American forms
@@ -647,14 +667,25 @@ trap 'rm -rf "$scratch"' EXIT
 PRAGMASTAT_TESTS_ROOT="$scratch" dotnet run --project \\
   cs/Pragmastat.TestGenerator/Pragmastat.TestGenerator.csproj >/dev/null
 status=0
-# The suites this generator owns, and only those: tests/ also holds Rust-generated and
-# hand-maintained suites it must not be blamed for.
-owned="center center-bounds spread spread-bounds shift shift-bounds ratio ratio-bounds \\
-       disparity disparity-bounds avg-spread avg-spread-bounds compare1 compare2 \\
-       pairwise-margin signed-rank-margin"
-for suite in $owned; do
-  diff -r -q "tests/$suite" "$scratch/tests/$suite" || status=1
+# Compare against what the regeneration actually produced, rather than against a list of suite
+# names kept anywhere. Two earlier versions kept a list: the first restated it in this file and
+# went stale when the generator gained tests/exp-function, which was then deleted and rewritten on
+# every run while this check compared sixteen other directories and passed; the second scraped the
+# list out of Program.cs, which is a text match that can come back short without coming back empty,
+# and a short list is the same silent gap wearing a different hat.
+#
+# The scratch tree is the generator's own statement of what it owns. Iterating over it needs no
+# list, cannot go stale, and fails loudly if regeneration produced nothing.
+produced="$(find "$scratch/tests" -mindepth 1 -maxdepth 1 -type d | wc -l)"
+if [ "$produced" -eq 0 ]; then
+  echo "ERROR: the generator produced no suites; nothing was compared." >&2
+  exit 1
+fi
+for dir in "$scratch"/tests/*/; do
+  suite="$(basename "$dir")"
+  diff -r -q "tests/$suite" "$dir" || status=1
 done
+echo "compared $produced generated suites"
 diff -r -q cs/tests "$scratch/cs/tests" || status=1
 if [ "$status" -ne 0 ]; then
   echo "ERROR: a generated fixture no longer matches its generator." >&2
@@ -981,6 +1012,27 @@ missing="$(git ls-files --deleted)"
 [ -z "$missing" ] || git checkout -- $missing
 """
 
+[tasks."docs:check"]
+description = "Assert the manual's prose still matches what it describes"
+# These live in their own task because the release pipeline used to restate the documentation
+# pipeline and omit them: docs:ci grew three checks and docs:ci:release kept running the old
+# five steps, so a release built the PDF and the site with none of them enforced.
+run = [
+    # Every fixture count stated in the manual must match the directory it describes. They are
+    # prose, they ship in the PDF and on the website, and four of them went stale the moment
+    # fixtures were added at the decision boundaries.
+    "python3 tests/check_manual_counts.py .",
+    # An operator defined inside a chapter is invisible to the website converter, so the PDF and
+    # the page disagree on one source without anything failing.
+    "python3 tests/check_local_operators.py .",
+    # Fail CI if any tracked file is missing from the working tree. The clean tasks delete
+    # committed generated artifacts (img/logo.png, the bounds-width tables) on the reasoning
+    # that build puts them back, which is true and which makes `clean` followed by a blanket
+    # `git add -A` a way to commit their deletion without noticing. It has happened once.
+    # `git ls-files --deleted` is the invariant that catches it, and it costs nothing.
+    "test -z \"$(git ls-files --deleted)\" || { echo 'ERROR: tracked files are missing from the working tree:' >&2; git ls-files --deleted >&2; echo 'A clean task removed a committed artifact and the build did not put it back.' >&2; exit 1; }",
+]
+
 [tasks."docs:ci"]
 description = "Run documentation CI pipeline"
 run = [
@@ -1000,14 +1052,7 @@ run = [
     # that build puts them back, which is true and which makes `clean` followed by a blanket
     # `git add -A` a way to commit their deletion without noticing. It has happened once.
     # `git ls-files --deleted` is the invariant that catches it, and it costs nothing.
-    # Every fixture count stated in the manual must match the directory it describes. They are
-    # prose, they ship in the PDF and on the website, and four of them went stale the moment
-    # fixtures were added at the decision boundaries.
-    "python3 tests/check_manual_counts.py .",
-    # An operator defined inside a chapter is invisible to the website converter, so the PDF and
-    # the page disagree on one source without anything failing.
-    "python3 tests/check_local_operators.py .",
-    "test -z \"$(git ls-files --deleted)\" || { echo 'ERROR: tracked files are missing from the working tree:' >&2; git ls-files --deleted >&2; echo 'A clean task removed a committed artifact and the build did not put it back.' >&2; exit 1; }",
+    { task = "docs:check" },
     { task = "pdf:build" },
     { task = "web:build" },
 ]
@@ -1021,6 +1066,7 @@ run = [
     { task = "docs:sync" },
     { task = "img:logo" },
     "git diff --exit-code || { echo 'ERROR: docs:sync produced uncommitted drift — regenerate and commit generated docs' >&2; exit 1; }",
+    { task = "docs:check" },
     { task = "pdf:build:release" },
     { task = "web:build:release" },
 ]
@@ -1055,7 +1101,7 @@ depends = ["cs:demo", "go:demo", "kt:demo", "py:demo", "r:demo", "rs:demo", "ts:
 
 [tasks."ci"]
 description = "Run CI pipeline for all language implementations"
-depends = ["cs:ci", "go:ci", "kt:ci", "py:ci", "r:ci", "rs:ci", "ts:ci", "docs:ci", "tests:check:rng-fixtures", "tests:check:conformance", "tests:check:generator-drift", "tests:check:spelling"]
+depends = ["cs:ci", "go:ci", "kt:ci", "py:ci", "r:ci", "rs:ci", "ts:ci", "docs:ci", "tests:check:rng-fixtures", "tests:check:conformance", "tests:check:generator-drift", "tests:check:spelling", "tests:check:coefficients"]
 
 # ==========================================================================
 # Version Task

--- a/py/AGENTS.md
+++ b/py/AGENTS.md
@@ -17,40 +17,40 @@ mise run py:pack     # Build and verify with twine
 ```
 py/
 ├── pragmastat/
-│   ├── __init__.py                # Public exports
-│   ├── estimators.py              # Public API: center, spread, shift, etc.
-│   ├── sample.py                  # Sample class with values, weights, unit
-│   ├── measurement.py             # Measurement frozen dataclass (value + unit)
-│   ├── measurement_unit.py        # MeasurementUnit frozen dataclass
-│   ├── bounds.py                  # Bounds frozen dataclass (lower, upper, unit)
-│   ├── unit_registry.py           # UnitRegistry for unit lookup by ID
-│   ├── assumptions.py             # Input validation and error types
-│   ├── pairwise_margin.py         # Margin calculation for shift bounds (internal)
-│   ├── sign_margin.py             # Sign margin for binomial CDF inversion
-│   ├── signed_rank_margin.py      # Signed-rank margin computation
-│   ├── min_misrate.py             # Minimum achievable misrate calculation
-│   ├── _binomial.py               # Binomial coefficient shared by the two above (internal)
-│   ├── additive_cumulative.py            # Standard normal CDF (Chebyshev-fitted erf/erfc)
-│   ├── exp_function.py            # Reproducible exp: range reduction plus fitted polynomial
-│   ├── rng.py                     # Deterministic xoshiro256++ PRNG
-│   ├── xoshiro256.py              # PRNG core implementation
-│   ├── center_impl.py             # O(n log n) Hodges-Lehmann algorithm
-│   ├── _center_quantiles_impl.py  # Center quantile binary search (internal)
-│   ├── spread_impl.py             # O(n log n) Shamos algorithm
-│   ├── shift_impl.py              # O((m+n) log L) shift quantiles
-│   ├── _constants.py              # Internal constants
-│   └── distributions/             # Uniform, Additive, Exp, Power, Multiplic
+│   ├── __init__.py               # Public exports
+│   ├── estimators.py             # Public API: center, spread, shift, etc.
+│   ├── sample.py                 # Sample class with values, weights, unit
+│   ├── measurement.py            # Measurement frozen dataclass (value + unit)
+│   ├── measurement_unit.py       # MeasurementUnit frozen dataclass
+│   ├── bounds.py                 # Bounds frozen dataclass (lower, upper, unit)
+│   ├── unit_registry.py          # UnitRegistry for unit lookup by ID
+│   ├── assumptions.py            # Input validation and error types
+│   ├── pairwise_margin.py        # Margin calculation for shift bounds (internal)
+│   ├── sign_margin.py            # Sign margin for binomial CDF inversion
+│   ├── signed_rank_margin.py     # Signed-rank margin computation
+│   ├── min_misrate.py            # Minimum achievable misrate calculation
+│   ├── _binomial.py              # Binomial coefficient shared by the two above (internal)
+│   ├── additive_cumulative.py    # Standard normal CDF (Chebyshev-fitted erf/erfc)
+│   ├── exp_function.py           # Reproducible exp: range reduction plus fitted polynomial
+│   ├── rng.py                    # Deterministic xoshiro256++ PRNG
+│   ├── xoshiro256.py             # PRNG core implementation
+│   ├── center_impl.py            # O(n log n) Hodges-Lehmann algorithm
+│   ├── _center_quantiles_impl.py # Center quantile binary search (internal)
+│   ├── spread_impl.py            # O(n log n) Shamos algorithm
+│   ├── shift_impl.py             # O((m+n) log L) shift quantiles
+│   ├── _constants.py             # Internal constants
+│   └── distributions/            # Uniform, Additive, Exp, Power, Multiplic
 ├── tests/
-│   ├── binary64.py                # Shared exactness predicates (payload comparison, hex reports)
-│   ├── test_assume_sorted.py      # assume-sorted equivalence + convergence-guard misuse
-│   ├── test_binary64.py           # Covers the exactness predicates themselves
-│   ├── test_invariance.py         # Mathematical property tests
-│   ├── test_mutation.py           # Raw-API input-mutation safety
-│   ├── test_negative_zero.py      # No estimator reports a -0.0 (payload-level)
-│   ├── test_pairwise_margin_consistency.py  # Binomial regressions behind the pairwise margin
-│   ├── test_performance.py        # Performance smoke test
-│   ├── test_reference.py          # JSON fixture validation (includes sample-construction, unit-propagation)
-│   └── test_shift_overflow.py     # Shift on extreme finite input
+│   ├── binary64.py                         # Shared exactness predicates (payload comparison, hex reports)
+│   ├── test_assume_sorted.py               # assume-sorted equivalence + convergence-guard misuse
+│   ├── test_binary64.py                    # Covers the exactness predicates themselves
+│   ├── test_invariance.py                  # Mathematical property tests
+│   ├── test_mutation.py                    # Raw-API input-mutation safety
+│   ├── test_negative_zero.py               # No estimator reports a -0.0 (payload-level)
+│   ├── test_pairwise_margin_consistency.py # Binomial regressions behind the pairwise margin
+│   ├── test_performance.py                 # Performance smoke test
+│   ├── test_reference.py                   # JSON fixture validation (includes sample-construction, unit-propagation)
+│   └── test_shift_overflow.py              # Shift on extreme finite input
 ├── examples/
 │   └── demo.py
 └── pyproject.toml

--- a/py/pragmastat/additive_cumulative.py
+++ b/py/pragmastat/additive_cumulative.py
@@ -24,8 +24,12 @@ def additive_cumulative(z: float) -> float:
         z: a standardized deviation, in units of spread from the center
 
     Returns:
-        Area under the standard normal curve from -infinity to x
+        Area under the standard Additive density from -infinity to z
     """
+    # NaN satisfies neither comparison below, so without this it would leave the tail branch as a
+    # finite 0 or 1 and an undefined input would be answered rather than reported.
+    if math.isnan(z):
+        return z
     t = abs(z) / _SQRT2
     if t < 0.5:
         # erf(t) / t as a polynomial in u = 8 * t^2 - 1

--- a/py/pragmastat/exp_function.py
+++ b/py/pragmastat/exp_function.py
@@ -82,9 +82,8 @@ def exp_function(y: float) -> float:
     # off the end. Reconstructing the same sum from the two halves of the reduction keeps them,
     # and costs nothing, being the same operations in a different order. Measured against a
     # 60-digit reference over the band these estimators reach, it halves the worst relative
-    # error, from 2.19e-16 to 1.20e-16, and raises the share of correctly rounded results from
-    # 72.6% to 90.0%. That is where fdlibm sits, which reaches it with a division this does not
-    # need.
+    # error, from 2.18e-16 to 1.27e-16, and raises the share of correctly rounded results from
+    # 73.6% to 90.2%. That is a shade better than fdlibm, which reaches 1.30e-16 with a division this does not need.
     p = 1.0 - ((lo - r * r * q) - hi)
 
     # Two scalings rather than one. Splitting k in half keeps the first factor inside the

--- a/py/tests/test_additive_cumulative.py
+++ b/py/tests/test_additive_cumulative.py
@@ -1,0 +1,50 @@
+"""``additive_cumulative`` has no answer for a NaN, and must say so rather than inventing one.
+
+Both of the function's range comparisons are false for a NaN, so without an explicit guard it
+leaves the tail branch as a finite 0 or 1: an undefined input answered rather than reported. The
+approximation it replaced propagated NaN, so losing that is a regression on behavior every port
+shares, and it is invisible to the margin fixtures because none of them passes a NaN.
+
+The assertions compare PAYLOADS: ``==`` reads the two zeros as equal and every NaN as unequal,
+and neither reading is the claim being made here.
+"""
+
+import math
+
+import pytest
+from binary64 import assert_identical
+
+from pragmastat.additive_cumulative import additive_cumulative
+
+
+def test_carries_nan_through():
+    assert math.isnan(additive_cumulative(math.nan)), "additive_cumulative(nan) should be nan"
+
+
+@pytest.mark.parametrize(
+    ("z", "expected"),
+    [
+        (math.inf, 1.0),
+        (-math.inf, 0.0),
+        (0.0, 0.5),
+        (-0.0, 0.5),
+    ],
+)
+def test_answers_the_defined_boundaries(z, expected):
+    assert_identical(additive_cumulative(z), expected, f"additive_cumulative({z!r})")
+
+
+def test_exp_function_cutoffs():
+    """The values outside the reduction band, which the shared fixture cannot carry.
+
+    JSON has no way to express an infinity, so the generated suite stops at 709.78 and these
+    arguments are covered here or nowhere.
+    """
+    from pragmastat.exp_function import exp_function
+
+    assert math.isnan(exp_function(math.nan))
+    assert exp_function(709.8) == math.inf
+    assert exp_function(math.inf) == math.inf
+    assert_identical(exp_function(-745.3), 0.0, "exp_function(-745.3)")
+    assert_identical(exp_function(-math.inf), 0.0, "exp_function(-inf)")
+    assert_identical(exp_function(0.0), 1.0, "exp_function(0)")

--- a/r/AGENTS.md
+++ b/r/AGENTS.md
@@ -20,34 +20,34 @@ mise run r:doc       # Build documentation with roxygen2
 ```
 r/pragmastat/
 ├── R/
-│   ├── aaa_constants.R          # Internal constants (loaded first)
-│   ├── aa_assumptions.R         # Input validation and error types
-│   ├── normalize_zero.R         # Drops the sign of a negative zero on estimator output
-│   ├── center.R                 # Center estimator
-│   ├── center_bounds.R          # Center confidence bounds
-│   ├── spread.R                 # Spread estimator
-│   ├── spread_bounds.R          # Spread confidence bounds
-│   ├── shift.R                  # Shift estimator
-│   ├── shift_bounds.R           # Shift confidence bounds
-│   ├── ratio.R                  # Ratio estimator
-│   ├── ratio_bounds.R           # Ratio confidence bounds
-│   ├── avg_spread.R             # Average spread
-│   ├── avg_spread_bounds.R      # Average spread confidence bounds
-│   ├── disparity.R              # Disparity (effect size)
-│   ├── disparity_bounds.R       # Disparity confidence bounds
-│   ├── pairwise_margin.R        # Margin calculation
-│   ├── sign_margin.R            # Sign margin for binomial CDF inversion
-│   ├── signed_rank_margin.R     # Signed-rank margin computation
-│   ├── min_misrate.R            # Minimum achievable misrate calculation
-│   ├── additive_cumulative.R           # Standard normal CDF (Chebyshev-fitted erf/erfc)
-│   ├── exp_function.R           # Reproducible exp: range reduction plus fitted polynomial
-│   ├── center_impl.R            # O(n log n) Hodges-Lehmann algorithm
-│   ├── center_quantiles_impl.R  # Center quantile binary search
-│   ├── spread_impl.R            # O(n log n) Shamos algorithm
-│   ├── shift_impl.R             # O((m+n) log L) shift quantiles
-│   ├── rng.R                    # Deterministic xoshiro256++ PRNG (R6 class)
-│   ├── xoshiro256.R             # PRNG core implementation (plain functions)
-│   └── dist_*.R                 # Distribution classes
+│   ├── aaa_constants.R         # Internal constants (loaded first)
+│   ├── aa_assumptions.R        # Input validation and error types
+│   ├── normalize_zero.R        # Drops the sign of a negative zero on estimator output
+│   ├── center.R                # Center estimator
+│   ├── center_bounds.R         # Center confidence bounds
+│   ├── spread.R                # Spread estimator
+│   ├── spread_bounds.R         # Spread confidence bounds
+│   ├── shift.R                 # Shift estimator
+│   ├── shift_bounds.R          # Shift confidence bounds
+│   ├── ratio.R                 # Ratio estimator
+│   ├── ratio_bounds.R          # Ratio confidence bounds
+│   ├── avg_spread.R            # Average spread
+│   ├── avg_spread_bounds.R     # Average spread confidence bounds
+│   ├── disparity.R             # Disparity (effect size)
+│   ├── disparity_bounds.R      # Disparity confidence bounds
+│   ├── pairwise_margin.R       # Margin calculation
+│   ├── sign_margin.R           # Sign margin for binomial CDF inversion
+│   ├── signed_rank_margin.R    # Signed-rank margin computation
+│   ├── min_misrate.R           # Minimum achievable misrate calculation
+│   ├── additive_cumulative.R   # Standard normal CDF (Chebyshev-fitted erf/erfc)
+│   ├── exp_function.R          # Reproducible exp: range reduction plus fitted polynomial
+│   ├── center_impl.R           # O(n log n) Hodges-Lehmann algorithm
+│   ├── center_quantiles_impl.R # Center quantile binary search
+│   ├── spread_impl.R           # O(n log n) Shamos algorithm
+│   ├── shift_impl.R            # O((m+n) log L) shift quantiles
+│   ├── rng.R                   # Deterministic xoshiro256++ PRNG (R6 class)
+│   ├── xoshiro256.R            # PRNG core implementation (plain functions)
+│   └── dist_*.R                # Distribution classes
 ├── tests/testthat/
 │   ├── helper-reference-tests.R
 │   ├── test-center.R

--- a/r/pragmastat/R/additive_cumulative.R
+++ b/r/pragmastat/R/additive_cumulative.R
@@ -24,6 +24,11 @@
 
 # additive_cumulative computes P(Z <= x) for a standard normal Z.
 additive_cumulative <- function(z) {
+  # NaN satisfies neither comparison below; in R the comparison yields NA and the branch errors
+  # instead of returning, so an undefined input has to be answered here.
+  if (is.na(z)) {
+    return(z)
+  }
   t <- abs(z) / sqrt(2)
   if (t < 0.5) {
     s <- t * t

--- a/r/pragmastat/R/exp_function.R
+++ b/r/pragmastat/R/exp_function.R
@@ -68,9 +68,8 @@ exp_function <- function(y) {
   # off the end. Reconstructing the same sum from the two halves of the reduction keeps them,
   # and costs nothing, being the same operations in a different order. Measured against a
   # 60-digit reference over the band these estimators reach, it halves the worst relative
-  # error, from 2.19e-16 to 1.20e-16, and raises the share of correctly rounded results from
-  # 72.6% to 90.0%. That is where fdlibm sits, which reaches it with a division this does
-  # not need.
+  # error, from 2.18e-16 to 1.27e-16, and raises the share of correctly rounded results from
+  # 73.6% to 90.2%. That is a shade better than fdlibm, which reaches 1.30e-16 with a division this does not need.
   p <- 1.0 - ((lo - r * r * q) - hi)
 
   # Two scalings rather than one. Splitting k in half keeps the first factor inside the

--- a/r/pragmastat/tests/testthat/test-exp-function.R
+++ b/r/pragmastat/tests/testthat/test-exp-function.R
@@ -92,19 +92,21 @@ test_that("exp_function tracks the platform exponential to about 2 ulp", {
 test_that("additive_cumulative carries NaN through and answers both infinities", {
   # Both of the function's range comparisons yield NA for a NaN, so without an explicit guard the
   # branch errors instead of returning. The approximation this replaced propagated NaN.
+  # expect_identical compares numerically by default, so it reads -0 as 0 and would pass on a
+  # negative zero. expect_exact compares payloads, which is the claim being made.
   expect_identical(additive_cumulative(NaN), NaN)
   expect_identical(additive_cumulative(NA_real_), NA_real_)
-  expect_identical(additive_cumulative(Inf), 1)
-  expect_identical(additive_cumulative(-Inf), 0)
-  expect_identical(additive_cumulative(0), 0.5)
+  expect_exact(additive_cumulative(Inf), 1, "additive_cumulative(Inf)")
+  expect_exact(additive_cumulative(-Inf), 0, "additive_cumulative(-Inf)")
+  expect_exact(additive_cumulative(0), 0.5, "additive_cumulative(0)")
 })
 
 test_that("exp_function returns the declared values outside the reduction band", {
   expect_identical(exp_function(NaN), NaN)
   expect_identical(exp_function(NA_real_), NA_real_)
-  expect_identical(exp_function(710), Inf)
-  expect_identical(exp_function(Inf), Inf)
-  expect_identical(exp_function(-746), 0)
-  expect_identical(exp_function(-Inf), 0)
-  expect_identical(exp_function(0), 1)
+  expect_exact(exp_function(710), Inf, "exp_function(710)")
+  expect_exact(exp_function(Inf), Inf, "exp_function(Inf)")
+  expect_exact(exp_function(-746), 0, "exp_function(-746)")
+  expect_exact(exp_function(-Inf), 0, "exp_function(-Inf)")
+  expect_exact(exp_function(0), 1, "exp_function(0)")
 })

--- a/r/pragmastat/tests/testthat/test-exp-function.R
+++ b/r/pragmastat/tests/testthat/test-exp-function.R
@@ -89,6 +89,16 @@ test_that("exp_function tracks the platform exponential to about 2 ulp", {
   expect_lt(max(abs(actual - expected) / expected), 2^-51)
 })
 
+test_that("additive_cumulative carries NaN through and answers both infinities", {
+  # Both of the function's range comparisons yield NA for a NaN, so without an explicit guard the
+  # branch errors instead of returning. The approximation this replaced propagated NaN.
+  expect_identical(additive_cumulative(NaN), NaN)
+  expect_identical(additive_cumulative(NA_real_), NA_real_)
+  expect_identical(additive_cumulative(Inf), 1)
+  expect_identical(additive_cumulative(-Inf), 0)
+  expect_identical(additive_cumulative(0), 0.5)
+})
+
 test_that("exp_function returns the declared values outside the reduction band", {
   expect_identical(exp_function(NaN), NaN)
   expect_identical(exp_function(NA_real_), NA_real_)

--- a/rs/AGENTS.md
+++ b/rs/AGENTS.md
@@ -16,29 +16,29 @@ mise run rs:bench    # Run benchmarks
 ```
 rs/pragmastat/
 ├── src/
-│   ├── lib.rs                     # Public exports
-│   ├── estimators.rs              # Public API: center, spread, shift, etc.
-│   ├── assumptions.rs             # Input validation and error types
-│   ├── pairwise_margin.rs         # Margin calculation for shift bounds (internal)
-│   ├── sign_margin.rs             # Sign margin for binomial CDF inversion (internal)
-│   ├── signed_rank_margin.rs      # Signed-rank margin computation (internal)
-│   ├── min_misrate.rs             # Minimum achievable misrate calculation (internal)
-│   ├── additive_cumulative.rs            # Standard normal CDF (Chebyshev erf/erfc fit) (internal)
-│   ├── exp_function.rs            # Reproducible exp, replacing the platform's (internal)
-│   ├── rng.rs                     # Deterministic xoshiro256++ PRNG
-│   ├── distributions/             # Sampling distributions (Uniform, Additive, Exp, Power, Multiplic)
-│   ├── center_impl.rs             # O(n log n) Hodges-Lehmann algorithm (internal)
-│   ├── center_quantiles_impl.rs   # Center quantile binary search (internal)
-│   ├── spread_impl.rs             # O(n log n) Shamos algorithm (internal)
-│   ├── shift_impl.rs              # O((m+n) log L) shift quantiles (internal)
-│   ├── xoshiro256.rs              # PRNG core implementation (internal)
-│   ├── splitmix64.rs              # Seed mixing (internal)
-│   ├── fnv1a.rs                   # Hash for deterministic seeding (internal)
-│   ├── avg_spread_tests.rs        # Average spread unit tests
-│   ├── avg_spread_bounds_tests.rs # Average spread bounds unit tests
-│   ├── disparity_bounds_tests.rs  # Disparity bounds unit tests
-│   ├── pairwise_margin_tests.rs   # Pairwise margin unit tests
-│   ├── ratio_bounds_tests.rs      # Ratio bounds error-priority tests
+│   ├── lib.rs                      # Public exports
+│   ├── estimators.rs               # Public API: center, spread, shift, etc.
+│   ├── assumptions.rs              # Input validation and error types
+│   ├── pairwise_margin.rs          # Margin calculation for shift bounds (internal)
+│   ├── sign_margin.rs              # Sign margin for binomial CDF inversion (internal)
+│   ├── signed_rank_margin.rs       # Signed-rank margin computation (internal)
+│   ├── min_misrate.rs              # Minimum achievable misrate calculation (internal)
+│   ├── additive_cumulative.rs      # Standard normal CDF (Chebyshev erf/erfc fit) (internal)
+│   ├── exp_function.rs             # Reproducible exp, replacing the platform's (internal)
+│   ├── rng.rs                      # Deterministic xoshiro256++ PRNG
+│   ├── distributions/              # Sampling distributions (Uniform, Additive, Exp, Power, Multiplic)
+│   ├── center_impl.rs              # O(n log n) Hodges-Lehmann algorithm (internal)
+│   ├── center_quantiles_impl.rs    # Center quantile binary search (internal)
+│   ├── spread_impl.rs              # O(n log n) Shamos algorithm (internal)
+│   ├── shift_impl.rs               # O((m+n) log L) shift quantiles (internal)
+│   ├── xoshiro256.rs               # PRNG core implementation (internal)
+│   ├── splitmix64.rs               # Seed mixing (internal)
+│   ├── fnv1a.rs                    # Hash for deterministic seeding (internal)
+│   ├── avg_spread_tests.rs         # Average spread unit tests
+│   ├── avg_spread_bounds_tests.rs  # Average spread bounds unit tests
+│   ├── disparity_bounds_tests.rs   # Disparity bounds unit tests
+│   ├── pairwise_margin_tests.rs    # Pairwise margin unit tests
+│   ├── ratio_bounds_tests.rs       # Ratio bounds error-priority tests
 │   └── signed_rank_margin_tests.rs # Signed-rank margin unit tests
 ├── tests/
 │   ├── assume_sorted_tests.rs             # assume-sorted equivalence

--- a/rs/pragmastat/src/additive_cumulative.rs
+++ b/rs/pragmastat/src/additive_cumulative.rs
@@ -12,6 +12,11 @@ use crate::exp_function::exp_function;
 /// contract on its own, so the two roundings this spells out are the two roundings that run,
 /// which is what the other six implementations do. `rs:check:fma` keeps it that way.
 pub fn additive_cumulative(z: f64) -> f64 {
+    // NaN satisfies neither comparison below, so without this it would leave the tail branch
+    // as a finite 0 or 1 and an undefined input would be answered rather than reported.
+    if z.is_nan() {
+        return z;
+    }
     let t = z.abs() / std::f64::consts::SQRT_2;
     if t < 0.5 {
         // erf(t)/t as a polynomial in u = 8*t^2 - 1.
@@ -76,5 +81,22 @@ pub fn additive_cumulative(z: f64) -> f64 {
         1.0 - 0.5 * erfc
     } else {
         0.5 * erfc
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::additive_cumulative;
+
+    /// Both of the function's range comparisons are false for a NaN, so without an explicit guard
+    /// it leaves the tail branch as a finite 0 or 1: an undefined input answered rather than
+    /// reported. The approximation this replaced propagated NaN.
+    #[test]
+    fn carries_nan_through_and_answers_both_infinities() {
+        assert!(additive_cumulative(f64::NAN).is_nan());
+        assert_eq!(additive_cumulative(f64::INFINITY), 1.0);
+        assert_eq!(additive_cumulative(f64::NEG_INFINITY), 0.0);
+        assert_eq!(additive_cumulative(0.0), 0.5);
+        assert_eq!(additive_cumulative(-0.0), 0.5);
     }
 }

--- a/rs/pragmastat/src/additive_cumulative.rs
+++ b/rs/pragmastat/src/additive_cumulative.rs
@@ -104,8 +104,16 @@ mod tests {
     #[test]
     fn carries_nan_through_and_answers_both_infinities() {
         assert!(additive_cumulative(f64::NAN).is_nan());
-        assert_bitwise("additive_cumulative(+inf)", 1.0, additive_cumulative(f64::INFINITY));
-        assert_bitwise("additive_cumulative(-inf)", 0.0, additive_cumulative(f64::NEG_INFINITY));
+        assert_bitwise(
+            "additive_cumulative(+inf)",
+            1.0,
+            additive_cumulative(f64::INFINITY),
+        );
+        assert_bitwise(
+            "additive_cumulative(-inf)",
+            0.0,
+            additive_cumulative(f64::NEG_INFINITY),
+        );
         assert_bitwise("additive_cumulative(+0)", 0.5, additive_cumulative(0.0));
         assert_bitwise("additive_cumulative(-0)", 0.5, additive_cumulative(-0.0));
     }

--- a/rs/pragmastat/src/additive_cumulative.rs
+++ b/rs/pragmastat/src/additive_cumulative.rs
@@ -87,6 +87,16 @@ pub fn additive_cumulative(z: f64) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::additive_cumulative;
+    use crate::conformance::bitwise_mismatch;
+
+    /// Payloads, not `==`. Every zero-valued expectation below would pass on a negative zero under
+    /// `assert_eq!`, which is the exact divergence class these suites exist to reject, and the
+    /// other six ports all use their payload predicate here.
+    fn assert_bitwise(what: &str, expected: f64, actual: f64) {
+        if let Some(message) = bitwise_mismatch(what, expected, actual) {
+            panic!("{message}");
+        }
+    }
 
     /// Both of the function's range comparisons are false for a NaN, so without an explicit guard
     /// it leaves the tail branch as a finite 0 or 1: an undefined input answered rather than
@@ -94,9 +104,9 @@ mod tests {
     #[test]
     fn carries_nan_through_and_answers_both_infinities() {
         assert!(additive_cumulative(f64::NAN).is_nan());
-        assert_eq!(additive_cumulative(f64::INFINITY), 1.0);
-        assert_eq!(additive_cumulative(f64::NEG_INFINITY), 0.0);
-        assert_eq!(additive_cumulative(0.0), 0.5);
-        assert_eq!(additive_cumulative(-0.0), 0.5);
+        assert_bitwise("additive_cumulative(+inf)", 1.0, additive_cumulative(f64::INFINITY));
+        assert_bitwise("additive_cumulative(-inf)", 0.0, additive_cumulative(f64::NEG_INFINITY));
+        assert_bitwise("additive_cumulative(+0)", 0.5, additive_cumulative(0.0));
+        assert_bitwise("additive_cumulative(-0)", 0.5, additive_cumulative(-0.0));
     }
 }

--- a/rs/pragmastat/src/exp_function.rs
+++ b/rs/pragmastat/src/exp_function.rs
@@ -100,8 +100,8 @@ pub(crate) fn exp_function(y: f64) -> f64 {
     // falls off the end. Reconstructing the same sum from the two halves of the reduction keeps
     // them, and costs nothing, being the same operations in a different order. Measured against a
     // 60-digit reference over the band these estimators reach, it halves the worst relative error,
-    // from 2.19e-16 to 1.28e-16, and raises the share of correctly rounded results from 72.6% to
-    // 90.3%. That is where fdlibm sits, which reaches it with a division this does not need.
+    // from 2.18e-16 to 1.27e-16, and raises the share of correctly rounded results from 73.6% to
+    // 90.2%. That is a shade better than fdlibm, which reaches 1.30e-16 with a division this does not need.
     let p = 1.0 - ((lo - r * r * q) - hi);
 
     // Two scalings rather than one. Splitting k in half keeps the first factor inside the
@@ -196,11 +196,22 @@ mod tests {
 
     #[test]
     fn cutoffs_and_nan() {
+        // Payloads for the zero-valued expectations: `assert_eq!` reads -0.0 as 0.0, and an
+        // underflow that returned a negative zero would pass while diverging from the other six.
+        let bits = |v: f64| v.to_bits();
         assert!(exp_function(f64::NAN).is_nan());
         assert_eq!(exp_function(709.8), f64::INFINITY);
         assert_eq!(exp_function(f64::INFINITY), f64::INFINITY);
-        assert_eq!(exp_function(-745.3), 0.0);
-        assert_eq!(exp_function(f64::NEG_INFINITY), 0.0);
+        assert_eq!(
+            bits(exp_function(-745.3)),
+            bits(0.0),
+            "underflow must be +0"
+        );
+        assert_eq!(
+            bits(exp_function(f64::NEG_INFINITY)),
+            bits(0.0),
+            "-inf must be +0"
+        );
         assert_eq!(exp_function(0.0), 1.0);
     }
 }

--- a/rs/pragmastat/src/exp_function.rs
+++ b/rs/pragmastat/src/exp_function.rs
@@ -100,8 +100,8 @@ pub(crate) fn exp_function(y: f64) -> f64 {
     // falls off the end. Reconstructing the same sum from the two halves of the reduction keeps
     // them, and costs nothing, being the same operations in a different order. Measured against a
     // 60-digit reference over the band these estimators reach, it halves the worst relative error,
-    // from 2.19e-16 to 1.20e-16, and raises the share of correctly rounded results from 72.6% to
-    // 90.0%. That is where fdlibm sits, which reaches it with a division this does not need.
+    // from 2.19e-16 to 1.28e-16, and raises the share of correctly rounded results from 72.6% to
+    // 90.3%. That is where fdlibm sits, which reaches it with a division this does not need.
     let p = 1.0 - ((lo - r * r * q) - hi);
 
     // Two scalings rather than one. Splitting k in half keeps the first factor inside the
@@ -164,6 +164,34 @@ mod tests {
             worst_ulp <= 2.0,
             "worst disagreement with the platform exp: {worst_ulp} ulp at y = {worst_at}"
         );
+    }
+
+    /// Both margins binary-search an expansion whose density term is this function, under the
+    /// assumption that the expansion is monotone in the index. A single inversion here would let
+    /// the search return either neighbor, and the two neighbors are different confidence bounds.
+    ///
+    /// The sweep walks adjacent doubles rather than a grid: an inversion between two representable
+    /// arguments is what the search can hit, and a grid steps straight over it. One port suffices
+    /// because all seven return identical bits on every argument, which the shared fixture pins.
+    #[test]
+    fn monotone_across_adjacent_doubles() {
+        for start in [-745.0, -100.0, -1.0, -0.3, 0.0, 0.3, 1.0, 100.0, 709.0] {
+            let mut y = start;
+            let mut previous = exp_function(y);
+            for _ in 0..20_000 {
+                y = f64::from_bits(if y >= 0.0 {
+                    y.to_bits() + 1
+                } else {
+                    y.to_bits() - 1
+                });
+                let current = exp_function(y);
+                assert!(
+                    current >= previous,
+                    "exp_function inverted at y = {y}: {current} < {previous}"
+                );
+                previous = current;
+            }
+        }
     }
 
     #[test]

--- a/rs/pragmastat/src/exp_function_tests.rs
+++ b/rs/pragmastat/src/exp_function_tests.rs
@@ -134,10 +134,23 @@ fn test_exp_function_reference() {
         }
     }
 
-    assert!(
-        checked > 0,
-        "No arguments were checked out of {} files",
+    // The size of the generated fixture: four files, 1032 arguments. Pinned rather than counted
+    // from the directory, because counting the directory and then asserting the count matches the
+    // directory asserts nothing. The other six ports pin the same two numbers; a loader that only
+    // asserts it did some work cannot see a file that stopped being read or an argument list that
+    // was truncated.
+    const FIXTURE_FILE_COUNT: usize = 4;
+    const FIXTURE_ARGUMENT_COUNT: usize = 1032;
+
+    assert_eq!(
+        json_files.len(),
+        FIXTURE_FILE_COUNT,
+        "exp-function: read {} files, expected {FIXTURE_FILE_COUNT}",
         json_files.len()
+    );
+    assert_eq!(
+        checked, FIXTURE_ARGUMENT_COUNT,
+        "exp-function: compared {checked} arguments, expected {FIXTURE_ARGUMENT_COUNT}"
     );
 
     assert!(

--- a/tests/README.md
+++ b/tests/README.md
@@ -64,7 +64,8 @@ tests/
 └── distributions/       # Distribution sampling tests
 ```
 
-`exp-function/` is the only suite that tests a function no public API exposes. It is there because
+`exp-function/` is the only suite whose function is internal in all seven ports. The margin
+suites test functions that are public in some of them and internal in others. It is there because
 the margins reach an exponential, IEEE 754 fixes nothing about one, and a last-bit difference
 there selects a different order statistic — so the seven implementations evaluate their own rather
 than the platform's. Every other suite reaches that function only through a margin, which covers

--- a/tests/check_coefficients.py
+++ b/tests/check_coefficients.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Assert the coefficients compiled into the seven ports are the ones the fit scripts produce.
+
+The manual says the coefficients are "reproducible rather than transcribed", and points at
+tests/oracles/fit_exp.py and tests/oracles/fit_additive_cumulative.py as their source. Nothing checked
+that. Both scripts printed their output and exited, no task ran them, and the constants live as
+literals in seven files: an edit to a script, or to one port's literal, would have gone unnoticed
+until somebody re-derived the fit by hand.
+
+Every coefficient is compared as a binary64 payload, not as text, because the ports spell the same
+double differently: Go writes 1.6086622436215554e-10, C# writes 1.6086622436215554E-10, and R
+writes 1.6086622436215554e-10 with a different number of trailing digits in places.
+
+The reference oracle's own self-check runs here too, for the same reason: it was given a failing
+exit status and still nothing invoked it.
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# One port per language. The parser finds the Horner chain by its shape rather than by line
+# numbers: an initializing assignment of the accumulator to a literal, then one step per
+# coefficient, each multiplying the accumulator by the reduced argument and adding the next one.
+SOURCES = {
+    "exp": [
+        ("go/exp_function.go", "q", "r"),
+        ("py/pragmastat/exp_function.py", "q", "r"),
+        ("rs/pragmastat/src/exp_function.rs", "q", "r"),
+        ("ts/src/expFunction.ts", "q", "r"),
+        ("kt/src/main/kotlin/dev/pragmastat/ExpFunction.kt", "q", "r"),
+        ("cs/Pragmastat/Functions/ExpFunction.cs", "q", "r"),
+        ("r/pragmastat/R/exp_function.R", "q", "r"),
+    ],
+    "additive": [
+        ("go/additive_cumulative.go", "p", "u"),
+        ("py/pragmastat/additive_cumulative.py", "p", "u"),
+        ("rs/pragmastat/src/additive_cumulative.rs", "p", "u"),
+        ("ts/src/additiveCumulative.ts", "p", "u"),
+        ("kt/src/main/kotlin/dev/pragmastat/AdditiveCumulative.kt", "p", "u"),
+        ("cs/Pragmastat/Functions/AdditiveCumulative.cs", "p", "u"),
+        ("r/pragmastat/R/additive_cumulative.R", "p", "u"),
+    ],
+}
+
+FLOAT = re.compile(r"[-+]?\d+\.\d+[eE][-+]?\d+")
+
+
+def run_fit(root: Path, script: str) -> list[list[float]]:
+    """Run a fit script and return one list of coefficients per polynomial it prints."""
+    python = root / "py" / ".venv" / "bin" / "python"
+    interpreter = str(python) if python.exists() else sys.executable
+    result = subprocess.run(
+        [interpreter, str(root / "tests" / "oracles" / script)],
+        capture_output=True,
+        text=True,
+        cwd=root,
+    )
+    if result.returncode != 0:
+        print(f"ERROR: {script} exited {result.returncode}", file=sys.stderr)
+        print(result.stderr, file=sys.stderr)
+        raise SystemExit(1)
+    chains = []
+    for line in result.stdout.split("\n"):
+        if line.startswith("POLY_"):
+            chains.append([float(v) for v in FLOAT.findall(line)])
+    return chains
+
+
+def horner_coefficients(root: Path, rel: str, accumulator: str, argument: str) -> list[list[float]]:
+    """One list of coefficients per Horner chain in a port, each in source order.
+
+    A step is any line that assigns the accumulator from itself times the argument, plus or minus a
+    literal: the seven ports spell the assignment differently (`=`, `<-`, `let mut`) and Go wraps
+    the product in a float64() conversion, so the pattern anchors on the two variable names and the
+    trailing literal rather than on the syntax around them.
+    """
+    literal = r"([-+]?\d+\.\d+(?:[eE][-+]?\d+)?)"
+    step = re.compile(
+        rf"^\s*{accumulator}\s*(?:=|<-)\s*.*\b{accumulator}\s*\*\s*(?:float64\()?{argument}"
+        rf"[^\n]*?([-+])\s*{literal}\s*;?\s*$",
+        re.M,
+    )
+    start = re.compile(
+        rf"^\s*(?:let\s+(?:mut\s+)?|var\s+|val\s+|double\s+|const\s+)?{accumulator}\s*(?::?=|<-)\s*{literal}\s*;?\s*$",
+        re.M,
+    )
+
+    chains: list[list[float]] = []
+    for line in (root / rel).read_text().split("\n"):
+        begin = start.match(line)
+        if begin:
+            chains.append([float(begin.group(1))])
+            continue
+        move = step.match(line)
+        if move and chains:
+            sign, value = move.group(1), move.group(2)
+            chains[-1].append(float(value) if sign == "+" else -float(value))
+    if not chains:
+        print(f"ERROR: found no Horner chain for {accumulator} in {rel}", file=sys.stderr)
+        raise SystemExit(1)
+    return chains
+
+
+def compare(name: str, expected: list[list[float]], root: Path) -> list[str]:
+    failures = []
+    for rel, accumulator, argument in SOURCES[name]:
+        chains = horner_coefficients(root, rel, accumulator, argument)
+        if len(chains) != len(expected):
+            failures.append(f"  {rel}: {len(chains)} Horner chains, the fit produces {len(expected)}")
+            continue
+        for chain_index, (found, want) in enumerate(zip(chains, expected)):
+            # The ports evaluate each chain from the highest degree down; the scripts print the
+            # coefficients lowest first.
+            if found and want and found[0] != want[0]:
+                found = list(reversed(found))
+            if len(found) != len(want):
+                failures.append(
+                    f"  {rel}: chain {chain_index} has {len(found)} coefficients, the fit produces {len(want)}"
+                )
+                continue
+            for index, (a, b) in enumerate(zip(found, want)):
+                if a != b:
+                    failures.append(
+                        f"  {rel}: chain {chain_index} coefficient {index} is {a!r}, the fit produces {b!r}"
+                    )
+    return failures
+
+
+def main() -> int:
+    root = Path(sys.argv[1] if len(sys.argv) > 1 else ".").resolve()
+
+    exp_coefficients = run_fit(root, "fit_exp.py")
+    additive_coefficients = run_fit(root, "fit_additive_cumulative.py")
+
+    failures = compare("exp", exp_coefficients, root) + compare("additive", additive_coefficients, root)
+
+    python = root / "py" / ".venv" / "bin" / "python"
+    interpreter = str(python) if python.exists() else sys.executable
+    oracle = subprocess.run(
+        [interpreter, str(root / "tests" / "oracles" / "additive_reference.py")],
+        capture_output=True,
+        text=True,
+        cwd=root,
+    )
+    if oracle.returncode != 0:
+        failures.append("  tests/oracles/additive_reference.py: its own self-check failed")
+        failures.append("    " + oracle.stdout.strip().replace("\n", "\n    "))
+
+    if failures:
+        print("ERROR: the shipped coefficients no longer match the scripts that produce them:", file=sys.stderr)
+        print("\n".join(failures), file=sys.stderr)
+        return 1
+
+    total = sum(len(c) for c in exp_coefficients) + sum(len(c) for c in additive_coefficients)
+    print(f"{total} coefficients match the fit scripts that produce them, in all seven ports")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/check_local_operators.py
+++ b/tests/check_local_operators.py
@@ -8,6 +8,11 @@ Both outputs come from one source and quietly disagree.
 That happened with MedianBounds, which rendered upright in the PDF and as eleven italic letters
 on the page, beside a CenterBounds that was upright in both. Nothing failed, because the LaTeX
 was valid.
+
+There are two routes to that state and the check covers both. One is defining the operator inside
+a chapter, where the converter never looks. The other is defining it in definitions.typ and not in
+definitions.yaml: the PDF reads the first file and the website reads the second, so an operator
+present in one and missing from the other produces the same silent divergence.
 """
 
 import re
@@ -15,11 +20,19 @@ import sys
 from pathlib import Path
 
 LOCAL_OP = re.compile(r"^\s*#let\s+(\w+)\s*=\s*math\.(op|underline|upright|bold|bb)\b", re.M)
+SHARED_OP = re.compile(r"^#let\s+(\w+)\s*=\s*math\.(?:op|underline|upright|bold|bb)\b", re.M)
+YAML_ENTRY = re.compile(r"^([A-Za-z]\w*)\s*:", re.M)
+
+# Only one direction is a defect. An operator in definitions.typ with no macro in definitions.yaml
+# renders upright in the PDF and italic on the page, which is the divergence this file exists to
+# stop. The reverse, a macro with no operator, is a dead entry: Typst fails loudly the moment
+# anything uses the name, so nothing can ship in that state.
 
 
 def main(repo_root):
     root = Path(repo_root)
     shared = root / "manual" / "definitions.typ"
+    macros = root / "manual" / "definitions.yaml"
     failures = []
 
     for source in sorted(root.glob("manual/**/*.typ")):
@@ -27,6 +40,12 @@ def main(repo_root):
             continue
         for match in LOCAL_OP.finditer(source.read_text()):
             failures.append(f"  {source.relative_to(root)}: #let {match.group(1)} = math.{match.group(2)}(...)")
+
+    # The PDF renders from definitions.typ and the page from definitions.yaml.
+    typst_ops = set(SHARED_OP.findall(shared.read_text()))
+    yaml_ops = set(YAML_ENTRY.findall(macros.read_text()))
+    for name in sorted(typst_ops - yaml_ops):
+        failures.append(f"  manual/definitions.yaml: no macro for {name}, which definitions.typ defines")
 
     if failures:
         print("ERROR: math operators are defined outside manual/definitions.typ:", file=sys.stderr)

--- a/tests/check_manual_counts.py
+++ b/tests/check_manual_counts.py
@@ -30,10 +30,18 @@ def main(repo_root):
     checked = 0
 
     for chapter in sorted(root.glob("manual/*/*-tests.typ")):
+        suite = chapter.parent.name
         match = PATTERN.search(chapter.read_text())
         if not match:
+            # A chapter whose sentence stops matching drops out of this check silently, and the
+            # check then reports success over a smaller set than it did the run before. The
+            # directory decides: a chapter that describes a shared suite has to state its size.
+            if (root / "tests" / suite).is_dir() and any((root / "tests" / suite).glob("*.json")):
+                failures.append(
+                    f"  {chapter.relative_to(root)}: tests/{suite} holds fixtures, but this chapter"
+                    f" states no count in a form this check recognizes"
+                )
             continue
-        suite = chapter.parent.name
         directory = root / "tests" / suite
         if not directory.is_dir():
             failures.append(f"  {chapter.relative_to(root)}: states a count but tests/{suite} does not exist")

--- a/tests/oracles/additive_reference.py
+++ b/tests/oracles/additive_reference.py
@@ -59,8 +59,29 @@ def erfc_ref(xf: float) -> D:
         return 1 - erf_series(x)
     return erfc_cf(x)
 
-if __name__ == "__main__":
-    # cross-check the two regimes on their overlap
+# The two regimes are used on either side of x = 2.5, and both converge on the overlap around it.
+# The continued fraction converges faster the larger x is, so the agreement is worst at the low end
+# of the overlap: 3e-47 at x = 2.0 against 2.8e-58 at the switch itself. The threshold is set below
+# the worst of those with room to spare. It was 1e-60 once, which nothing on the overlap reaches,
+# and the check printed a line saying so on every run without failing.
+AGREEMENT_THRESHOLD = D(10) ** -45
+
+def check_regimes_agree() -> bool:
+    """Cross-check the two regimes on their overlap. Returns True when they agree."""
+    ok = True
     for t in ("2.0", "2.2", "2.4", "2.49"):
-        a = 1 - erf_series(D(t)); b = erfc_cf(D(t))
-        print(f"x={t}: series={str(a)[:24]} cf={str(b)[:24]} agree={abs(a-b)/a < D(10)**-60}")
+        a = 1 - erf_series(D(t))
+        b = erfc_cf(D(t))
+        rel = abs(a - b) / a
+        agree = rel < AGREEMENT_THRESHOLD
+        ok = ok and agree
+        print(f"x={t}: series={str(a)[:24]} cf={str(b)[:24]} relative={rel:.3e} agree={agree}")
+    return ok
+
+if __name__ == "__main__":
+    import sys
+
+    if not check_regimes_agree():
+        print("ERROR: the two regimes disagree on their overlap", file=sys.stderr)
+        sys.exit(1)
+    print("the two regimes agree on their overlap")

--- a/tools/src/math_conv.rs
+++ b/tools/src/math_conv.rs
@@ -57,6 +57,10 @@ pub fn typst_to_latex(
     // Convert Typst line breaks and handle alignment
     result = convert_alignment(&result);
 
+    // The thin spaces were placed before the word mappings ran; drop the ones that ended up
+    // after a control word, which carries its own spacing.
+    result = drop_thin_space_after_commands(&result);
+
     result
 }
 
@@ -115,10 +119,14 @@ fn apply_definitions_outside_text(input: &str, definitions: &HashMap<String, Str
     result
 }
 
-/// Find matching closing brace, accounting for nesting
+/// Byte offset of the `}` closing a group whose `{` has already been consumed.
+///
+/// Bytes, not character positions, for the reason given on `find_matching_paren`: every caller
+/// slices the string with the result, and the two agree only until the first multibyte character.
+/// This converter produces one itself, since an escaped solidus becomes U+2044 before these run.
 fn find_matching_brace(s: &str) -> Option<usize> {
     let mut depth = 1;
-    for (i, c) in s.chars().enumerate() {
+    for (i, c) in s.char_indices() {
         match c {
             '{' => depth += 1,
             '}' => {
@@ -134,15 +142,16 @@ fn find_matching_brace(s: &str) -> Option<usize> {
 }
 
 /// Convert Typst op("name") to LaTeX \operatorname{name}
+// The walk is over byte offsets, not character positions. find_matching_paren returns a byte
+// offset and the slices below are byte slices, so mixing the two panics on the first multibyte
+// character in the expression and silently mis-slices before that. The manual has multibyte
+// characters in its maths.
 fn convert_op(input: &str) -> String {
     let mut result = String::new();
     let mut i = 0;
-    let chars: Vec<char> = input.chars().collect();
 
-    while i < chars.len() {
-        // Check for op( pattern
-        if i + 3 < chars.len() && chars[i] == 'o' && chars[i + 1] == 'p' && chars[i + 2] == '(' {
-            // Found op(, now look for the content
+    while i < input.len() {
+        if input[i..].starts_with("op(") {
             let start = i + 3;
             if let Some(end) = find_matching_paren(&input[start..]) {
                 let inner = &input[start..start + end];
@@ -153,8 +162,9 @@ fn convert_op(input: &str) -> String {
                 continue;
             }
         }
-        result.push(chars[i]);
-        i += 1;
+        let c = input[i..].chars().next().expect("i is a char boundary");
+        result.push(c);
+        i += c.len_utf8();
     }
 
     result
@@ -257,10 +267,12 @@ fn convert_binom(input: &str) -> String {
     result
 }
 
-/// Find comma separator in function arguments, respecting nesting
+/// Byte offset of the comma separating two arguments at the top level of a call.
+///
+/// Bytes, not character positions: see `find_matching_paren`.
 fn find_comma_in_args(s: &str) -> Option<usize> {
     let mut depth = 0;
-    for (i, c) in s.chars().enumerate() {
+    for (i, c) in s.char_indices() {
         match c {
             '(' | '[' | '{' => depth += 1,
             ')' | ']' | '}' => depth -= 1,
@@ -479,16 +491,16 @@ fn convert_attach(input: &str) -> String {
     result
 }
 
-/// Find the first comma that's not escaped (not preceded by \)
+/// Byte offset of the first comma not preceded by a backslash.
+///
+/// Bytes, not character positions: see `find_matching_paren`.
 fn find_unescaped_comma(s: &str) -> Option<usize> {
-    let chars: Vec<char> = s.chars().collect();
-    for (i, &c) in chars.iter().enumerate() {
-        if c == ',' {
-            // Check if preceded by backslash
-            if i == 0 || chars[i - 1] != '\\' {
-                return Some(i);
-            }
+    let mut previous = None;
+    for (i, c) in s.char_indices() {
+        if c == ',' && previous != Some('\\') {
+            return Some(i);
         }
+        previous = Some(c);
     }
     None
 }
@@ -519,6 +531,49 @@ fn find_matching_paren(s: &str) -> Option<usize> {
 }
 
 /// Convert Typst "text" to LaTeX \text{text}
+/// Removes a thin space that ended up directly after a LaTeX control word.
+///
+/// `convert_text_quotes` inserts the gap before the word mappings run, so at that point a Typst
+/// operator such as `and` is still a bare word and looks like an atom; by the time it becomes
+/// `\land` the gap is already in the string. Control words carry their own spacing and the extra
+/// width shows: after `\begin{cases}` it indents the first branch relative to the others, which
+/// reads as a misaligned column. There were 34 of these in the rendered manual.
+///
+/// `\text`, `\mathrm`, `\operatorname`, `\mathbf` and `\mathit` set an atom rather than spacing,
+/// so a word following one of those still needs separating from it.
+fn drop_thin_space_after_commands(input: &str) -> String {
+    const ATOM_COMMANDS: [&str; 5] = ["text", "mathrm", "operatorname", "mathbf", "mathit"];
+    let mut result = String::with_capacity(input.len());
+    let mut rest = input;
+    while let Some(at) = rest.find(r"\;") {
+        let (before, after) = rest.split_at(at);
+        result.push_str(before);
+        let keep = match before.rfind('\\') {
+            Some(start) => {
+                let word: String = before[start + 1..]
+                    .chars()
+                    .take_while(char::is_ascii_alphabetic)
+                    .collect();
+                let tail = &before[start + 1 + word.len()..];
+                // A control word either stands alone (\land) or takes a braced argument
+                // (\begin{cases}, \text{if}). Both are commands; only the ones that SET an atom
+                // earn a following gap.
+                let is_command = !word.is_empty()
+                    && (tail.is_empty() || (tail.starts_with('{') && tail.ends_with('}')));
+                let sets_an_atom = ATOM_COMMANDS.contains(&word.as_str());
+                !is_command || sets_an_atom
+            }
+            None => true,
+        };
+        if keep {
+            result.push_str(r"\;");
+        }
+        rest = &after[2..];
+    }
+    result.push_str(rest);
+    result
+}
+
 fn convert_text_quotes(input: &str) -> String {
     let chars: Vec<char> = input.chars().collect();
     let mut result = String::new();
@@ -571,8 +626,13 @@ fn convert_text_quotes(input: &str) -> String {
         let needs_gap = j < chars.len() && (chars[j].is_alphanumeric() || chars[j] == '"');
         if needs_gap {
             result.push_str("\\;");
+            i = j;
         }
-        i = j;
+        // Otherwise the source whitespace is left alone rather than swallowed. A row of a display
+        // equation ends with a space and a backslash, and convert_alignment recognizes a row break
+        // by that exact sequence. Dropping the space left `\text{...}\` + newline, which KaTeX
+        // reads as a control space rather than a row break, and four rows of SplitMix64 rendered
+        // as one line.
     }
 
     // Close any unclosed text brace
@@ -990,7 +1050,12 @@ fn size_delimiters_to_content(input: &str) -> String {
     let mut result = String::with_capacity(input.len());
     let mut i = 0;
     while i < input.len() {
-        let c = bytes[i] as char;
+        // Decode the character rather than casting the byte. `bytes[i] as char` yields the wrong
+        // scalar for anything non-ASCII, and the `len_utf8()` that follows then advances by the
+        // wrong stride, so the character is replaced by a substitute and its continuation bytes
+        // are consumed as if they were characters of their own. The manual has no non-ASCII inside
+        // math today, which is the only reason this has not corrupted anything.
+        let c = input[i..].chars().next().expect("i is a char boundary");
 
         // Subscripts and superscripts are set small, and a stretched delimiter there inflates the
         // script rather than fitting it. Copy those groups through untouched.
@@ -1757,18 +1822,13 @@ fn wrap_text_subscripts(input: &str, prefix: &str) -> String {
 /// Typst `lr()` creates auto-sizing delimiters. For example:
 /// - `lr(|x|)` -> `\left\lvert x\right\rvert`
 /// - `lr((a+b))` -> `\left(a+b\right)`
+// Byte offsets throughout, for the reason given on convert_op.
 fn convert_lr(input: &str) -> String {
     let mut result = String::new();
     let mut i = 0;
-    let input_chars: Vec<char> = input.chars().collect();
 
-    while i < input_chars.len() {
-        // Check for lr( pattern
-        if i + 2 < input_chars.len()
-            && input_chars[i] == 'l'
-            && input_chars[i + 1] == 'r'
-            && input_chars[i + 2] == '('
-        {
+    while i < input.len() {
+        if input[i..].starts_with("lr(") {
             // Found lr(, now find the matching closing paren
             let start = i + 3; // After "lr("
             if let Some(end) = find_matching_paren(&input[start..]) {
@@ -1804,8 +1864,9 @@ fn convert_lr(input: &str) -> String {
             }
         }
 
-        result.push(input_chars[i]);
-        i += 1;
+        let c = input[i..].chars().next().expect("i is a char boundary");
+        result.push(c);
+        i += c.len_utf8();
     }
 
     result
@@ -3078,6 +3139,121 @@ mod tests {
         let defs = HashMap::new();
         let result = typst_to_latex("a\\/b", &defs, false);
         assert_eq!(result, "a/b");
+    }
+
+    /// A row of a display equation that ends with a quoted string still ends with a row break.
+    ///
+    /// The thin-space rule after a closing quote used to swallow every following space, including
+    /// the one that separates the row from its trailing backslash. `convert_alignment` recognizes a
+    /// break by that exact sequence, so the break was never doubled and `KaTeX` read the lone
+    /// backslash as a control space: the four rows of `SplitMix64` rendered as one long line.
+    /// A quoted word after a LaTeX control word gets no thin space.
+    ///
+    /// The gap is inserted before the word mappings run, when a Typst operator is still a bare
+    /// word and looks like an atom, so the decision has to be revisited once the mapping has
+    /// happened. Control words carry their own spacing; `\begin{cases}` in particular indents
+    /// the first branch relative to the others when a gap follows it.
+    /// Non-ASCII inside a display equation survives conversion.
+    ///
+    /// Three finders returned character positions while their callers sliced by bytes, and the
+    /// sized-delimiter pass decoded characters by casting a byte. Both defects are invisible on
+    /// ASCII and silent on anything else: the first mis-slices, the second substitutes a
+    /// replacement character and eats the continuation bytes.
+    #[test]
+    fn non_ascii_inside_math_survives() {
+        let defs = HashMap::new();
+        for input in [
+            // The multibyte character has to sit INSIDE the argument list, before the separator:
+            // that is where a character position and a byte offset disagree.
+            "binom(1 \\/ 2, k)",
+            "binom(n \u{2248} m, k \\/ 2)",
+            "attach(1 \\/ 2, b: \"\u{03B1}\")",
+            "alpha = binom(n, k) dot 1 \\/ 2",
+            "lr((1 \\/ 2 + \u{2248} + sqrt(x)))",
+            "\"\u{2248}\" quad x = 1 \\/ 2",
+        ] {
+            for display in [true, false] {
+                let result = typst_to_latex(input, &defs, display);
+                assert!(
+                    !result.is_empty(),
+                    "conversion produced nothing for {input:?}"
+                );
+                assert!(
+                    !result.contains('\u{FFFD}'),
+                    "a character was replaced during conversion of {input:?}: {result}"
+                );
+                assert!(
+                    !result.contains('\u{2044}'),
+                    "the fraction marker survived conversion in {input:?}: {result}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_control_word_does_not_earn_a_thin_space() {
+        let defs = HashMap::new();
+        for (input, forbidden) in [
+            ("metric = Spread and \"seed\" != \"null\"", r"\land\;"),
+            ("x quad \"where\" y", r"\quad\;"),
+            ("a times \"b\"", r"\times\;"),
+        ] {
+            for display in [true, false] {
+                let result = typst_to_latex(input, &defs, display);
+                assert!(
+                    !result.contains(forbidden),
+                    "stray thin space after a control word in {input:?}: {result}"
+                );
+            }
+        }
+
+        // The exception: text-setting commands produce an atom, and a word after one still needs
+        // separating from it.
+        let kept = typst_to_latex("\"if\" \"then\"", &defs, true);
+        assert!(
+            kept.contains(r"\;"),
+            "the gap between two set words was dropped: {kept}"
+        );
+    }
+
+    #[test]
+    fn a_row_ending_in_a_quoted_string_keeps_its_break() {
+        let defs = HashMap::new();
+        let input = "x &<- x + \"0x9e3779b97f4a7c15\" \\\nz &<- z + 1";
+        let result = typst_to_latex(input, &defs, true);
+        assert!(result.contains("\\\\"), "the row break was lost: {result}");
+        assert!(
+            !result.contains("}\\\n"),
+            "a lone backslash survived, which KaTeX reads as a control space: {result}"
+        );
+    }
+
+    /// op(...) and lr(...) survive a multibyte character earlier in the expression.
+    ///
+    /// Both walked character positions and then sliced the input by those positions as if they
+    /// were byte offsets. Before the first multibyte character the two agree, so the defect is
+    /// invisible; after one, the slice either lands mid-character and panics or cuts in the wrong
+    /// place. The fraction marker this converter uses internally is U+2044, three bytes wide.
+    #[test]
+    fn op_and_lr_survive_a_multibyte_character() {
+        let defs = HashMap::new();
+        for input in [
+            "alpha \\/ beta + op(\"erfc\")(t)",
+            "1 \\/ 2 + lr(|x - y|)",
+            "sum_(i=1)^n 1 \\/ n dot lr((x_i - macron(x)))",
+        ] {
+            for display in [true, false] {
+                let result = typst_to_latex(input, &defs, display);
+                assert!(
+                    !result.is_empty(),
+                    "conversion produced nothing for {input:?}"
+                );
+                assert!(
+                    !result.contains('\u{2044}'),
+                    "the fraction marker survived conversion in {input:?}: {result}"
+                );
+            }
+        }
     }
 
     /// A group containing a multi-byte character must not be mis-sliced.

--- a/ts/AGENTS.md
+++ b/ts/AGENTS.md
@@ -26,7 +26,7 @@ ts/
 │   ├── signedRankMargin.ts    # Signed-rank margin computation
 │   ├── minMisrate.ts          # Minimum achievable misrate calculation
 │   ├── binomial.ts            # Binomial coefficient shared by the two above (internal)
-│   ├── additiveCumulative.ts         # Standard normal CDF (Chebyshev-fitted erf/erfc)
+│   ├── additiveCumulative.ts  # Standard normal CDF (Chebyshev-fitted erf/erfc)
 │   ├── expFunction.ts         # The exponential the margin path uses instead of Math.exp
 │   ├── rng.ts                 # Deterministic xoshiro256++ PRNG
 │   ├── xoshiro256.ts          # PRNG core implementation
@@ -37,16 +37,16 @@ ts/
 │   ├── constants.ts           # Internal constants
 │   └── distributions/         # Uniform, Additive, Exp, Power, Multiplic
 ├── tests/
-│   ├── bitwise.ts                 # The binary64-payload comparison every exact suite uses
-│   ├── expFunction.test.ts        # 2**n exactness and the cross-port payloads of expFunction
-│   ├── reference.test.ts          # JSON fixture validation
-│   ├── invariance.test.ts         # Mathematical property tests
-│   ├── assumeSorted.test.ts       # assumeSorted=true vs default-path equivalence
-│   ├── centerImplGuard.test.ts    # centerImpl convergence guard + Bounds.contains
-│   ├── spreadImplGuard.test.ts    # spreadImpl convergence guard
-│   ├── mutation.test.ts           # Caller arrays and Samples are never mutated
-│   ├── ratioBoundsErrors.test.ts  # ratioBounds assumption-error priority
-│   ├── properties.test.ts         # Unit propagation, misrate domain, n==2 symmetry
+│   ├── bitwise.ts                # The binary64-payload comparison every exact suite uses
+│   ├── expFunction.test.ts       # 2**n exactness and the cross-port payloads of expFunction
+│   ├── reference.test.ts         # JSON fixture validation
+│   ├── invariance.test.ts        # Mathematical property tests
+│   ├── assumeSorted.test.ts      # assumeSorted=true vs default-path equivalence
+│   ├── centerImplGuard.test.ts   # centerImpl convergence guard + Bounds.contains
+│   ├── spreadImplGuard.test.ts   # spreadImpl convergence guard
+│   ├── mutation.test.ts          # Caller arrays and Samples are never mutated
+│   ├── ratioBoundsErrors.test.ts # ratioBounds assumption-error priority
+│   ├── properties.test.ts        # Unit propagation, misrate domain, n==2 symmetry
 │   └── performance.test.ts
 ├── examples/
 │   └── demo.ts

--- a/ts/src/additiveCumulative.ts
+++ b/ts/src/additiveCumulative.ts
@@ -21,6 +21,11 @@ import { expFunction } from './expFunction';
  * @returns Area under the standard normal curve from -infinity to x
  */
 export function additiveCumulative(z: number): number {
+  // NaN satisfies neither comparison below, so without this it would leave the tail branch as a
+  // finite 0 or 1 and an undefined input would be answered rather than reported.
+  if (Number.isNaN(z)) {
+    return z;
+  }
   const t = Math.abs(z) / Math.SQRT2;
   if (t < 0.5) {
     const s = t * t;

--- a/ts/src/expFunction.ts
+++ b/ts/src/expFunction.ts
@@ -94,8 +94,8 @@ export function expFunction(y: number): number {
   // end. Reconstructing the same sum from the two halves of the reduction keeps them, and costs
   // nothing, being the same operations in a different order. Measured against a 60-digit
   // reference over the band these estimators reach, it halves the worst relative error, from
-  // 2.19e-16 to 1.20e-16, and raises the share of correctly rounded results from 72.6% to 90.0%.
-  // That is where fdlibm sits, which reaches it with a division this does not need.
+  // 2.18e-16 to 1.27e-16, and raises the share of correctly rounded results from 73.6% to 90.2%.
+  // That is a shade better than fdlibm, which reaches 1.30e-16 with a division this does not need.
   // The grouping is load-bearing and left to right: 1.0 - ((lo - r*r*q) - hi).
   const p = 1.0 - (lo - r * r * q - hi);
 

--- a/ts/tests/expFunction.test.ts
+++ b/ts/tests/expFunction.test.ts
@@ -1,4 +1,5 @@
 import { pow2, expFunction } from '../src/expFunction';
+import { additiveCumulative } from '../src/additiveCumulative';
 import { expectBitwise } from './bitwise';
 
 // The exponential is the one library call on the margin path that IEEE 754 leaves free, so
@@ -68,5 +69,18 @@ describe('expFunction', () => {
     expect(expFunction(Infinity)).toBe(Infinity);
     expectBitwise('expFunction(-Infinity)', expFunction(-Infinity), 0);
     expect(Number.isNaN(expFunction(NaN))).toBe(true);
+  });
+});
+
+describe('additiveCumulative', () => {
+  // Both of the function's range comparisons are false for a NaN, so without an explicit guard
+  // it leaves the tail branch as a finite 0 or 1: an undefined input answered rather than
+  // reported. The approximation this replaced propagated NaN, so losing it would be a regression.
+  it('carries NaN through and answers both infinities', () => {
+    expect(Number.isNaN(additiveCumulative(NaN))).toBe(true);
+    expectBitwise('additiveCumulative(Infinity)', additiveCumulative(Infinity), 1);
+    expectBitwise('additiveCumulative(-Infinity)', additiveCumulative(-Infinity), 0);
+    expectBitwise('additiveCumulative(0)', additiveCumulative(0), 0.5);
+    expectBitwise('additiveCumulative(-0)', additiveCumulative(-0), 0.5);
   });
 });


### PR DESCRIPTION
Six checks reported success in exactly the state they exist to reject, and each was found by introducing the defect and watching the guard pass. The spelling check walked the tree and picked up the R build artifacts, including a copy of itself whose table of forbidden forms is a list of British spellings, which made the second CI run on any machine red. `go:check:fma` piped the cross-compile into `grep`, which hides the build's exit status. The Kotlin suite read fixtures Gradle did not know about, so an edited fixture left the previous result in place and the suite passed in under a second without running.

Base is `fp/07-nan-and-completion`.

## Appendix

The remaining three: `tests:check:generator-drift` restated the generator's list of owned suites and went stale when the generator gained one; `docs:ci:release` restated `docs:ci` and omitted the checks it had gained; `check_manual_counts` silently dropped any chapter whose sentence stopped matching its regex.

Also corrects eleven figures the new chapters stated. The accuracy table gave the 1993 reference implementation and this function the same worst relative error; measured over one band in one run, the system library reaches 1.11e-16 and 99.9% correctly rounded, this function 1.27e-16 and 90.2%, fdlibm 1.30e-16 and 90.2%, the Go runtime 2.42e-16 and 86.5%.
