### PR TITLE
Compile the TypeScript tests with the config written for them

### DIFF
--- a/ts/jest.config.js
+++ b/ts/jest.config.js
@@ -1,6 +1,12 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  // ts-jest compiles with tsconfig.json unless told which one to use, and that config excludes
+  // tests/. tsconfig.test.json exists for exactly this and was wired to nothing, so the test files
+  // were compiled under a config that does not describe them.
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.test.json' }],
+  },
   roots: ['<rootDir>/tests'],
   testMatch: ['**/*.test.ts'],
   collectCoverageFrom: [

--- a/ts/tsconfig.test.json
+++ b/ts/tsconfig.test.json
@@ -1,7 +1,14 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": "."
+    "rootDir": ".",
+    "types": [
+      "jest",
+      "node"
+    ]
   },
-  "include": ["src/**/*", "tests/**/*"]
+  "include": [
+    "src/**/*",
+    "tests/**/*"
+  ]
 }


### PR DESCRIPTION
`jest.config.js` sets the ts-jest preset without naming a tsconfig, so ts-jest fell back to `tsconfig.json` — which excludes `tests/`. `tsconfig.test.json` exists for exactly this and was referenced by nothing, so every test file was type-checked under a config that does not describe it. TypeScript 5 hid this by resolving `@types/*` regardless; TypeScript 6 does not, which is why #97 fails with 1154 tests unable to find `describe`. Verified under both compilers: 1154 pass on 5.9.3 and on 6.0.3.

Unblocks #97.