### PR TITLE
Resolve modules the way Node has resolved them since 16

### DIFF
--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -1,8 +1,10 @@
 {
   "compilerOptions": {
     "target": "ES2023",
-    "module": "commonjs",
-    "lib": ["ES2023"],
+    "module": "node16",
+    "lib": [
+      "ES2023"
+    ],
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,
@@ -18,8 +20,17 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
-    "moduleResolution": "node"
+    "moduleResolution": "node16",
+    "types": [
+      "node"
+    ]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests"
+  ]
 }


### PR DESCRIPTION
`moduleResolution` was `node`, which TypeScript now calls node10 and reports as deprecated — it stops functioning in TypeScript 7. The setting predates package exports maps and this package ships one, so the compiler was resolving imports by rules the runtime stopped using years ago. `node16` is the pairing that matches what the package already declares, and it stops the compiler inferring `@types/*`, so `@types/node` is now named explicitly.

The published output is unchanged: compiling before and after gives byte-identical `.js` and `.d.ts` across all of `dist`, with only the source path inside the `.map` files differing between the two build directories.

Unblocks #97.